### PR TITLE
[OTTO connector] Manage availability and payload

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     hooks:
     - id: black
       args: [
-        --check,
         --line-length=100,
       ]
   - repo: https://github.com/PyCQA/flake8

--- a/otto_connector/src/otto_connector/connector.py
+++ b/otto_connector/src/otto_connector/connector.py
@@ -241,9 +241,6 @@ class OTTOConnector:
         else:
             self.logger.info(f"Unknown command received: {command_name}")
 
-        # Notify the proxy manager of the changes
-        self.robots[robot_id] = robot
-
     def run_recipe(self, otto_id, recipe_id, waiting_time):
         """Run a maintenance recipe on the robot.
 

--- a/otto_connector/src/otto_connector/connector.py
+++ b/otto_connector/src/otto_connector/connector.py
@@ -136,6 +136,7 @@ class OTTOConnector:
             "v2.robots.batteries",
             "v2.robots.places",
             "v2.robots.states",
+            "v2.robots.payloads",
             "v2.missions",
         )
         self.runner = ApplicationRunner(
@@ -211,6 +212,12 @@ class OTTOConnector:
                 self.http_client.pause_autonomy(otto_id)
             elif msg == "resume_autonomy":
                 self.http_client.resume_autonomy(otto_id)
+            elif msg == "clear_payload":
+                self.http_client.clear_payload(otto_id)
+            elif msg == "available":
+                self.http_client.set_availability(otto_id, True)
+            elif msg == "unavailable":
+                self.http_client.set_availability(otto_id, False)
             elif re.search("_mission$", msg):
                 # Get current mission ID from the Mission Tracking data
                 mission_id = robot.event_key_values.get(InOrbitDataKeys.MISSION_TRACKING, {}).get(

--- a/otto_connector/src/otto_connector/http_client.py
+++ b/otto_connector/src/otto_connector/http_client.py
@@ -311,10 +311,10 @@ class HTTPClient:
         return self._evaluate_jsonrpc_response(res, "setRobotMaintenanceMode")
 
     def clear_payload(self, otto_id):
-        """Clear the robot's payload if any.
+        """Clear the robot's payloads if any.
 
         Args:
-            otto_id (str): ID of the robot to clear the payload for via the FM.
+            otto_id (str): ID of the robot to clear the payloads for via the FM.
 
         Returns:
             Whether the command was dispatched successfully.

--- a/otto_connector/src/otto_connector/http_client.py
+++ b/otto_connector/src/otto_connector/http_client.py
@@ -314,7 +314,7 @@ class HTTPClient:
         """Clear the robot's payload if any.
 
         Args:
-            mission_id (str): ID of the mission to be paused.
+            otto_id (str): ID of the robot to clear the payload for via the FM.
 
         Returns:
             Whether the command was dispatched successfully.
@@ -362,7 +362,7 @@ class HTTPClient:
         """Set the robot as available / unavailable.
 
         Args:
-            mission_id (str): ID of the mission to be paused.
+            otto_id (str): ID of the robot to set as available/unavailable.
             is_available (bool): Whether the robot is available or not.
 
         Returns:

--- a/otto_connector/src/otto_connector/http_client.py
+++ b/otto_connector/src/otto_connector/http_client.py
@@ -310,6 +310,26 @@ class HTTPClient:
         )
         return self._evaluate_jsonrpc_response(res, "setRobotMaintenanceMode")
 
+    def clear_payload(self, otto_id):
+        """Clear the robot's payload if any.
+
+        Args:
+            mission_id (str): ID of the mission to be paused.
+
+        Returns:
+            Whether the command was dispatched successfully.
+        """
+        res = self._post(
+            self.fleet_url + "/v2/operations",
+            {
+                "id": uuid.uuid4().int,
+                "jsonrpc": "2.0",
+                "method": "setRobotPayload",
+                "params": {"id": otto_id, "payload_id": None},
+            },
+        )
+        return self._evaluate_jsonrpc_response(res, "setRobotPayload")
+
     def send_recipe(self, otto_id, recipe_id):
         """Request a robot to dispatch a recipe.
 
@@ -337,6 +357,27 @@ class HTTPClient:
             },
         )
         return self._evaluate_jsonrpc_response(res, "sendRobotRecipe")
+
+    def set_availability(self, otto_id, is_available):
+        """Set the robot as available / unavailable.
+
+        Args:
+            mission_id (str): ID of the mission to be paused.
+            is_available (bool): Whether the robot is available or not.
+
+        Returns:
+            Whether the command was dispatched successfully.
+        """
+        res = self._post(
+            self.fleet_url + "/v2/operations",
+            {
+                "id": uuid.uuid4().int,
+                "jsonrpc": "2.0",
+                "method": "setRobotAvailability",
+                "params": {"id": otto_id, "available": is_available},
+            },
+        )
+        return self._evaluate_jsonrpc_response(res, "setRobotAvailability")
 
     def get_tasks(self, params=None):
         """Query a list of tasks with the specified parameters.

--- a/otto_connector/src/otto_connector/robot.py
+++ b/otto_connector/src/otto_connector/robot.py
@@ -49,6 +49,7 @@ class OttoRobot:
             InOrbitDataKeys.ROBOT_STATES: [],
             # List of current `sub_system_state` values (unrepeated)
             InOrbitDataKeys.SUBSYSTEM_STATES: [],
+            InOrbitDataKeys.PAYLOAD_ID: None,  # string,
         }
 
         # Save the last published event key-values to avoid publishing them every time.

--- a/otto_connector/src/otto_connector/robot.py
+++ b/otto_connector/src/otto_connector/robot.py
@@ -49,7 +49,8 @@ class OttoRobot:
             InOrbitDataKeys.ROBOT_STATES: [],
             # List of current `sub_system_state` values (unrepeated)
             InOrbitDataKeys.SUBSYSTEM_STATES: [],
-            InOrbitDataKeys.PAYLOAD_IDS: None,  # string,
+            # List of current payload ids for the robot
+            InOrbitDataKeys.PAYLOAD_IDS: [],
         }
 
         # Save the last published event key-values to avoid publishing them every time.
@@ -60,4 +61,4 @@ class OttoRobot:
         self.current_robot_status_raw = {}
 
         # Set of current payload ids for a robot as published by the FM.
-        self.current_robot_payloads = set()
+        self.current_payloads = set()

--- a/otto_connector/src/otto_connector/robot.py
+++ b/otto_connector/src/otto_connector/robot.py
@@ -49,12 +49,15 @@ class OttoRobot:
             InOrbitDataKeys.ROBOT_STATES: [],
             # List of current `sub_system_state` values (unrepeated)
             InOrbitDataKeys.SUBSYSTEM_STATES: [],
-            InOrbitDataKeys.PAYLOAD_ID: None,  # string,
+            InOrbitDataKeys.PAYLOAD_IDS: None,  # string,
         }
 
         # Save the last published event key-values to avoid publishing them every time.
         self.last_published_event_values = {}
 
-        # Dictionary of currently active state records of a robot as published by the FM, indexed by
-        # record id.
+        # Dictionary of currently active state records of a robot as published by the FM, indexed
+        # by record id.
         self.current_robot_status_raw = {}
+
+        # Set of current payload ids for a robot as published by the FM.
+        self.current_robot_payloads = set()

--- a/otto_connector/src/otto_connector/values.py
+++ b/otto_connector/src/otto_connector/values.py
@@ -46,4 +46,4 @@ class InOrbitDataKeys:
     ONLINE_STATUS = "online"
     ROBOT_STATES = "robot_states"
     SUBSYSTEM_STATES = "sub_system_states"
-    PAYLOAD_ID = "payload_id"
+    PAYLOAD_IDS = "payload_ids"

--- a/otto_connector/src/otto_connector/values.py
+++ b/otto_connector/src/otto_connector/values.py
@@ -46,3 +46,4 @@ class InOrbitDataKeys:
     ONLINE_STATUS = "online"
     ROBOT_STATES = "robot_states"
     SUBSYSTEM_STATES = "sub_system_states"
+    PAYLOAD_ID = "payload_id"

--- a/otto_connector/src/otto_connector/wamp_client.py
+++ b/otto_connector/src/otto_connector/wamp_client.py
@@ -217,6 +217,13 @@ class WampClient(ApplicationSession):
             robot.event_key_values[InOrbitDataKeys.ROBOT_STATES] = last_robot_states
             robot.event_key_values[InOrbitDataKeys.SUBSYSTEM_STATES] = last_sub_system_states
 
+            if any(
+                state in last_sub_system_states for state in ["ESTOP", "UNAVAILABLE", "BLOCKED"]
+            ):
+                robot.telemetry_key_values[InOrbitDataKeys.MISSION_STATUS] = InOrbitModeTags.ERROR
+            elif "MANUAL" in last_robot_states:
+                robot.telemetry_key_values[InOrbitDataKeys.MISSION_STATUS] = InOrbitModeTags.MANUAL
+
             # Send online status on a separate key value
             # The FM explicitly sends NO_HEARTBEAT as subsystem state (and OFFLINE as system state)
             # if the robot is offline, and removes it when it is online

--- a/otto_connector/src/otto_connector/wamp_client.py
+++ b/otto_connector/src/otto_connector/wamp_client.py
@@ -250,13 +250,12 @@ class WampClient(ApplicationSession):
             payload_id = payload.get("id")
 
             if message == "added" or message == "all":
-                robot.current_robot_payloads.add(payload_id)
-
+                robot.current_payloads.add(payload_id)
             elif message == "removed":
-                robot.current_robot_payloads.remove(payload_id)
+                robot.current_payloads.remove(payload_id)
 
             # Update the robot proxy object's reference to the payload IDs
-            robot.event_key_values[InOrbitDataKeys.PAYLOAD_IDS] = list(robot.current_robot_payloads)
+            robot.event_key_values[InOrbitDataKeys.PAYLOAD_IDS] = list(robot.current_payloads)
 
             # Update the proxy dictionary to notify the manager
             self.robots[inorbit_id] = robot

--- a/otto_connector/src/otto_connector/wamp_client.py
+++ b/otto_connector/src/otto_connector/wamp_client.py
@@ -79,6 +79,10 @@ class WampClient(ApplicationSession):
         elif topic == "v2.robots.states":
             self._handle_states_event(topic, args, message)
 
+        # Batteries data topic
+        elif topic == "v2.robots.payloads":
+            self._handle_payloads_event(topic, args, message)
+
         # Mission creation and updates
         elif topic == "v2.missions":
             self._handle_missions_event(topic, args, message)
@@ -152,15 +156,14 @@ class WampClient(ApplicationSession):
     def _handle_states_event(self, topic, args, message):
         """
         Update robot states.
+
         `message` can be either "added", "removed" or "all".
         When an "added" message is received, the state record is added to the robot's state, and
         gets removed on "removed".
         """
 
         def create_state_pair(record):
-            """
-            Create a dictionary with system_state and sub_system_state keys from a state record.
-            """
+            """Create a dict with system_state and sub_system_state keys from a state record."""
             return {
                 "system_state": record.get("system_state"),
                 "sub_system_state": record.get("sub_system_state"),
@@ -244,6 +247,27 @@ class WampClient(ApplicationSession):
                 "name": place.get("name"),
                 "id": place.get("id"),
             }
+
+            # Update the proxy dictionary to notify the manager
+            self.robots[inorbit_id] = robot
+
+    def _handle_payloads_event(self, topic, args, message):
+        """Update robot's current place."""
+        # TODO(@Tom743): Check schema when having more robots, same situation as in
+        # `_handle_batteries_event()`.
+
+        payloads = args[0]
+        for payload in payloads:
+            otto_id = payload["robot"]
+            inorbit_id = self.id_index.get(otto_id)
+            if not inorbit_id:
+                self.logger.warning(
+                    f"Received payload data for robot {otto_id} "
+                    "which is not registered in the connector"
+                )
+                return
+            robot: OttoRobot = self.robots[inorbit_id]
+            robot.key_values[InOrbitDataKeys.PAYLOAD_ID] = payload.get("name", "")
 
             # Update the proxy dictionary to notify the manager
             self.robots[inorbit_id] = robot


### PR DESCRIPTION
### ☑️ Your checklist for this pull request

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **main branch** (left side). Also you should start *your branch* off *our main*.
- [x] Check if your code additions will fail code linting checks.

### 🗒️ Description

Adds two new features to the OTTO connector:

- Managing robot availability through InOrbit Actions: allows setting a robot as available or unavailable.
- Publishes robot payloads and allows clearing a payload through an InOrbit Action.

### 📺 Demo

Clearing a payload
![clear_payload](https://github.com/inorbit-ai/inorbit-robot-connectors/assets/13956234/b1423db4-be26-419c-b910-7d67133c0794)

Setting robot's availability

![available](https://github.com/inorbit-ai/inorbit-robot-connectors/assets/13956234/668bd05e-a757-4613-89f3-7ae658bb5b80)

