### PR TITLE
API version selector

### DIFF
--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -122,8 +122,8 @@ flake8 --max-line-length=100 --exclude venv
 ```bash
 # Create the virtualenv if not active already
 virtualenv venv/
-pip install -e '.[dev]'
 . venv/bin/activate
+pip install -e '.[dev]'
 pytest -v
 ```
 

--- a/mir_connector/inorbit_mir_connector/config/mir100_model.py
+++ b/mir_connector/inorbit_mir_connector/config/mir100_model.py
@@ -32,6 +32,7 @@ default_mir100_config = {
 # Expected values
 CONNECTOR_TYPE = "mir100"
 
+
 class MiR100ConfigModel(BaseModel):
     """
     Specific configuration for MiR100 connector.

--- a/mir_connector/inorbit_mir_connector/config/mir100_model.py
+++ b/mir_connector/inorbit_mir_connector/config/mir100_model.py
@@ -5,8 +5,9 @@
 from pydantic import BaseModel, field_validator
 from .config_base_model import EdgeConnectorModel
 from .utils import read_yaml
+from ..src.mir_api import APIS
 
-# TODO: leverate ruamel.yaml capabilities to add comments to
+# TODO: leverage ruamel.yaml capabilities to add comments to
 # the yaml and improve how the default configuration section
 # that gets added automatically looks.
 default_mir100_config = {
@@ -30,8 +31,6 @@ default_mir100_config = {
 
 # Expected values
 CONNECTOR_TYPE = "mir100"
-MIR_API_VERSION = "v2.0"
-
 
 class MiR100ConfigModel(BaseModel):
     """
@@ -49,9 +48,9 @@ class MiR100ConfigModel(BaseModel):
 
     @field_validator("mir_api_version")
     def api_version_validation(cls, mir_api_version):
-        if mir_api_version != MIR_API_VERSION:
+        if mir_api_version not in APIS.keys():
             raise ValueError(
-                f"Unexpected MiR API version '{mir_api_version}'. Expected '{MIR_API_VERSION}'"
+                f"MiR API version '{mir_api_version}' is not supported. Supported versions are: {', '.join(APIS.keys())}"
             )
         return mir_api_version
 

--- a/mir_connector/inorbit_mir_connector/config/mir100_model.py
+++ b/mir_connector/inorbit_mir_connector/config/mir100_model.py
@@ -51,7 +51,8 @@ class MiR100ConfigModel(BaseModel):
     def api_version_validation(cls, mir_api_version):
         if mir_api_version not in APIS.keys():
             raise ValueError(
-                f"MiR API version '{mir_api_version}' is not supported. Supported versions are: {', '.join(APIS.keys())}"
+                f"MiR API version '{mir_api_version}' is not supported. "
+                f"Supported versions are: {', '.join(APIS.keys())}"
             )
         return mir_api_version
 

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -12,8 +12,7 @@ from inorbit_edge.robot import COMMAND_MESSAGE
 from inorbit_edge.robot import COMMAND_NAV_GOAL
 from inorbit_edge.robot import RobotSession
 from inorbit_edge.video import OpenCVCamera
-from .mir_api import MirApiV2
-from .mir_api import MirWebSocketV2
+from .mir_api import APIS
 from .mission import MirInorbitMissionTracking
 from ..config.mir100_model import MiR100Config
 
@@ -42,9 +41,11 @@ class Mir100Connector:
         log_level = config.log_level.value
         self.logger = logging.getLogger(name=self.__class__.__name__)
         self.logger.setLevel(log_level)
+        self.api_version = config.connector_config.mir_api_version
+        self.logger.debug(f"Using MiR API version: {self.api_version}")
 
         # Configure the connection to the robot
-        self.mir_api = MirApiV2(
+        self.mir_api = APIS[self.api_version]["rest"](
             mir_host_address=config.connector_config.mir_host_address,
             mir_username=config.connector_config.mir_username,
             mir_password=config.connector_config.mir_password,
@@ -54,7 +55,7 @@ class Mir100Connector:
         )
 
         # Configure the ws connection to the robot
-        self.mir_ws = MirWebSocketV2(
+        self.mir_ws = APIS[self.api_version]["ws"](
             mir_host_address=config.connector_config.mir_host_address,
             mir_ws_port=config.connector_config.mir_ws_port,
             mir_use_ssl=config.connector_config.mir_use_ssl,

--- a/mir_connector/inorbit_mir_connector/src/mir_api/__init__.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/__init__.py
@@ -1,3 +1,8 @@
 from .mir_api_base import MirApiBaseClass  # noqa: F401
 from .mir_api_v2 import MirApiV2  # noqa: F401
 from .mir_api_v2 import MirWebSocketV2  # noqa: F401
+
+# Available API versions
+APIS = {
+    "v2.0": {"rest": MirApiV2, "ws": MirWebSocketV2},
+}

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -18,6 +18,7 @@ from inorbit_mir_connector.config.mir100_model import MiR100Config
 API_VERSION = "v2.0"
 MirApi = APIS[API_VERSION]["rest"]
 
+
 # NOTE(b-Tomas): Added some example data below to help creating rea
 @pytest.fixture
 def connector(monkeypatch):

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -10,18 +10,20 @@ import threading
 import websocket
 from inorbit_mir_connector.src.connector import Mir100Connector
 from unittest.mock import MagicMock, Mock, call
-from inorbit_mir_connector.src.mir_api import MirApiV2
+from inorbit_mir_connector.src.mir_api import APIS
 import inorbit_mir_connector.src.connector
 from inorbit_edge.robot import RobotSession
 from inorbit_mir_connector.config.mir100_model import MiR100Config
 
+API_VERSION = "v2.0"
+MirApi = APIS[API_VERSION]["rest"]
 
 # NOTE(b-Tomas): Added some example data below to help creating rea
 @pytest.fixture
 def connector(monkeypatch):
     monkeypatch.setenv("INORBIT_KEY", "abc123")
-    monkeypatch.setattr(MirApiV2, "_create_api_session", MagicMock())
-    monkeypatch.setattr(MirApiV2, "_create_web_session", MagicMock())
+    monkeypatch.setattr(MirApi, "_create_api_session", MagicMock())
+    monkeypatch.setattr(MirApi, "_create_web_session", MagicMock())
     monkeypatch.setattr(websocket, "WebSocketApp", MagicMock())
     monkeypatch.setattr(RobotSession, "connect", MagicMock())
     monkeypatch.setattr(inorbit_mir_connector.src.connector.os, "makedirs", Mock())
@@ -125,8 +127,8 @@ def test_registers_user_scripts_config(monkeypatch):
 
     def create_connector(user_scripts):
         monkeypatch.setenv("INORBIT_KEY", "abc123")
-        monkeypatch.setattr(MirApiV2, "_create_api_session", MagicMock())
-        monkeypatch.setattr(MirApiV2, "_create_web_session", MagicMock())
+        monkeypatch.setattr(MirApi, "_create_api_session", MagicMock())
+        monkeypatch.setattr(MirApi, "_create_web_session", MagicMock())
         monkeypatch.setattr(websocket, "WebSocketApp", MagicMock())
         monkeypatch.setattr(RobotSession, "connect", MagicMock())
         monkeypatch.setattr(RobotSession, "register_commands_path", MagicMock())


### PR DESCRIPTION
### 🗒️ Description

Adds an API version to API python class dictionary.

When an unsupported API version is specified, the error message displays:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for MiR100Config
connector_config.mir_api_version
  Value error, MiR API version 'v3.0' is not supported. Supported versions are: v2.0 [type=value_error, input_value='v3.0', input_type=str]
```
