### PR TITLE
Instock Connector: Fix `instock_api_url` YAML key

### DIFF
--- a/instock_connector/config/myinstock.example.yaml
+++ b/instock_connector/config/myinstock.example.yaml
@@ -7,7 +7,7 @@ instock-asrs-1:
   connector_update_freq: 5.0
 
   connector_config:
-    instock_base_url: https://ca.instock.com/incus/v1
+    instock_api_url: https://ca.instock.com/incus/v1
     instock_api_version: v1
     instock_org_id: myorg
     instock_site_id: x.y.z-A


### PR DESCRIPTION
### Description

Replace `instock_base_url` with `instock_api_url` in the example YAML file. This configuration is then read in [`instock_connector/inorbit_instock_connector/src/config/config_instock.py#L52`](https://github.com/inorbit-ai/inorbit-robot-connectors/blob/a63517ed87f67b587ad08573103f0d6c570adec6/instock_connector/inorbit_instock_connector/src/config/config_instock.py#L52)
