### PR TITLE
Use waypoint navigation over missions

### DIFF
--- a/mir_connector/config/my_fleet.example.yaml
+++ b/mir_connector/config/my_fleet.example.yaml
@@ -15,7 +15,7 @@
       scaling: 0.3 # Percentage of the original image size (optional)
       quality: 60 # JPEG quality (0-100) (optional)
   # Configuration specific for the connector that will connect this robot
-  connector_type: mir100
+  connector_type: MiR100
   connector_config:
     mir_host_address: localhost
     mir_host_port: 80
@@ -25,6 +25,7 @@
     mir_username: username
     mir_password: password
     mir_api_version: v2.0
+    mir_firmware_version: v2
     # Toggle InOrbit Mission Tracking features. https://developer.inorbit.ai/tutorials#mission-tracking-tutorial
     # Mission Tracking features are not available on every InOrbit edition.
     enable_mission_tracking: false

--- a/mir_connector/inorbit_mir_connector/config/mir100_model.py
+++ b/mir_connector/inorbit_mir_connector/config/mir100_model.py
@@ -15,7 +15,7 @@ default_mir100_config = {
     "location_tz": "America/Los_Angeles",
     "log_level": "INFO",
     "cameras": [],
-    "connector_type": "mir100",
+    "connector_type": "MiR100",
     "user_scripts_dir": "path/to/user/scripts",
     "env_vars": {"ENV_VAR_NAME": "env_var_value"},
     "maps": {},
@@ -27,16 +27,19 @@ default_mir100_config = {
         "mir_enable_ws": True,
         "mir_username": "",
         "mir_password": "",
+        "mir_firmware_version": "v2",
         "enable_mission_tracking": True,
         "mir_api_version": "v2.0",
     },
 }
 
 # Expected values
-CONNECTOR_TYPE = "mir100"
+CONNECTOR_TYPES = ["MiR100", "MiR250"]
+FIRMWARE_VERSIONS = ["v2", "v3"]
 MIR_API_VERSION = "v2.0"
 
 
+# TODO(b-Tomas): Rename all MiR100* to MiR* to make more generic
 class MiR100ConfigModel(BaseModel):
     """
     Specific configuration for MiR100 connector.
@@ -50,6 +53,7 @@ class MiR100ConfigModel(BaseModel):
     mir_username: str
     mir_password: str
     mir_api_version: str
+    mir_firmware_version: str
     enable_mission_tracking: bool
 
     @field_validator("mir_api_version")
@@ -59,6 +63,15 @@ class MiR100ConfigModel(BaseModel):
                 f"Unexpected MiR API version '{mir_api_version}'. Expected '{MIR_API_VERSION}'"
             )
         return mir_api_version
+
+    @field_validator("mir_firmware_version")
+    def firmware_version_validation(cls, mir_firmware_version):
+        if mir_firmware_version not in FIRMWARE_VERSIONS:
+            raise ValueError(
+                f"Unexpected MiR firmware version '{mir_firmware_version}'. "
+                f"Expected one of '{FIRMWARE_VERSIONS}'"
+            )
+        return mir_firmware_version
 
 
 class MiR100Config(InorbitConnectorConfig):
@@ -70,9 +83,9 @@ class MiR100Config(InorbitConnectorConfig):
 
     @field_validator("connector_type")
     def connector_type_validation(cls, connector_type):
-        if connector_type != CONNECTOR_TYPE:
+        if connector_type not in CONNECTOR_TYPES:
             raise ValueError(
-                f"Unexpected connector type '{connector_type}'. Expected '{CONNECTOR_TYPE}'"
+                f"Unexpected connector type '{connector_type}'. Expected one of '{CONNECTOR_TYPES}'"
             )
         return connector_type
 

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -28,7 +28,7 @@ MIR_INORBIT_MISSIONS_GROUP_NAME = "InOrbit Temporary Missions Group"
 MIR_MOVE_DISTANCE_THRESHOLD = 0.1
 
 # Remove missions created in the temporary missions group every 12 hours
-MISSIONS_GARBAGE_COLLECTION_INTERVAL_SECS = 10  # 12 * 60 * 60
+MISSIONS_GARBAGE_COLLECTION_INTERVAL_SECS = 12 * 60 * 60
 
 
 # TODO(b-Tomas): Rename all MiR100* to MiR* to make more generic

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -6,7 +6,7 @@ from time import sleep
 import pytz
 import math
 import uuid
-import multiprocessing
+from threading import Thread
 from inorbit_connector.connector import Connector
 from inorbit_edge.robot import COMMAND_CUSTOM_COMMAND
 from inorbit_edge.robot import COMMAND_MESSAGE
@@ -207,8 +207,8 @@ class Mir100Connector(Connector):
         if self.ws_enabled:
             self.mir_ws.connect()
         # Start garbage collection for missions
-        self._missions_gc_process = multiprocessing.Process(target=self._missions_garbage_collector)
-        self._missions_gc_process.start()
+        # Running with daemon=True will kill the thread when the main thread is done executing
+        Thread(target=self._missions_garbage_collector, daemon=True).start()
 
     def _disconnect(self):
         """Disconnect from any external services"""
@@ -216,7 +216,6 @@ class Mir100Connector(Connector):
         super()._disconnect()
         if self.ws_enabled:
             self.mir_ws.disconnect()
-        self._missions_gc_process.terminate()
 
     def _execution_loop(self):
         """The main execution loop for the connector"""

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -4,6 +4,7 @@
 
 import pytz
 import math
+import uuid
 from inorbit_connector.connector import Connector
 from inorbit_edge.robot import COMMAND_CUSTOM_COMMAND
 from inorbit_edge.robot import COMMAND_MESSAGE
@@ -14,13 +15,19 @@ from .mission import MirInorbitMissionTracking
 from ..config.mir100_model import MiR100Config
 
 
-# Publish updates every 1s
-CONNECTOR_UPDATE_FREQ = 1
-
 # Available MiR states to select via actions
 MIR_STATE = {3: "READY", 4: "PAUSE", 11: "MANUALCONTROL"}
 
+# Connector missions group name
+# If a group with this name exists it will be used, otherwise it will be created
+# At shutdown, the group will be deleted
+MIR_INORBIT_MISSIONS_GROUP_NAME = "InOrbit Temporary Missions Group"
+# Distance threshold for MiR move missions in meters
+# Used in waypoints sent via missions when the WS interface is not enabled
+MIR_MOVE_DISTANCE_THRESHOLD = 0.1
 
+
+# TODO(b-Tomas): Rename all MiR100* to MiR* to make more generic
 class Mir100Connector(Connector):
     """MiR100 connector.
 
@@ -40,6 +47,7 @@ class Mir100Connector(Connector):
             register_user_scripts=True,
             create_user_scripts_dir=True,
         )
+        self.config = config
 
         # Configure the connection to the robot
         self.mir_api = MirApiV2(
@@ -78,6 +86,9 @@ class Mir100Connector(Connector):
             loglevel=config.log_level.value,
             enable_io_mission_tracking=config.connector_config.enable_mission_tracking,
         )
+
+        # Get or create the required missions and mission groups
+        self.setup_connector_missions()
 
     def _inorbit_command_handler(self, command_name, args, options):
         """Callback method for command messages.
@@ -147,7 +158,7 @@ class Mir100Connector(Connector):
         elif command_name == COMMAND_NAV_GOAL:
             self._logger.info(f"Received '{command_name}'!. {args}")
             pose = args[0]
-            self.mir_api.send_waypoint(pose)
+            self.send_waypoint_over_missions(pose)
         elif command_name == COMMAND_MESSAGE:
             msg = args[0]
             if msg == "inorbit_pause":
@@ -166,6 +177,7 @@ class Mir100Connector(Connector):
 
     def _disconnect(self):
         """Disconnect from any external services"""
+        self.cleanup_connector_missions()
         super()._disconnect()
         if self.ws_enabled:
             self.mir_ws.disconnect()
@@ -245,3 +257,79 @@ class Mir100Connector(Connector):
             self.mission_tracking.report_mission(self.status, self.metrics)
         except Exception:
             self._logger.exception("Error reporting mission")
+
+    def send_waypoint_over_missions(self, pose):
+        """Use the connector's mission group to create a move mission to a designated pose."""
+        mission_id = str(uuid.uuid4())
+        connector_type = self.config.connector_type
+        firmware_version = self.config.connector_config.mir_firmware_version
+
+        self.mir_api.create_mission(
+            group_id=self.missions_group_id,
+            name="Move to waypoint",
+            guid=mission_id,
+            description="Mission created by InOrbit",
+        )
+        param_values = {
+            "x": float(pose["x"]),
+            "y": float(pose["y"]),
+            "theta": math.degrees(float(pose["yaw"])),
+        }
+        if connector_type == "MiR100" and firmware_version == "v2":
+            param_values["retries"] = 5
+        elif connector_type == "MiR250" and firmware_version == "v3":
+            param_values["blocked_path_timeout"] = 60.0
+        else:
+            self._logger.warning(
+                f"Not supported connector type and firmware version combination for waypoint "
+                f"navigation: {connector_type} {firmware_version}. Will attempt to send waypoint "
+                "based on firmware version."
+            )
+            if firmware_version == "v2":
+                param_values["retries"] = 5
+            else:
+                param_values["blocked_path_timeout"] = 60.0
+
+        action_parameters = [
+            {"value": v, "input_name": None, "guid": str(uuid.uuid4()), "id": k}
+            for k, v in param_values.items()
+        ]
+        self.mir_api.add_action_to_mission(
+            action_type="move_to_position",
+            mission_id=mission_id,
+            parameters=action_parameters,
+            priority=1,
+        )
+        self.mir_api.queue_mission(mission_id)
+
+    def setup_connector_missions(self):
+        """Find and store the required missions and mission groups, or create them if they don't
+        exist."""
+        self._logger.info("Setting up connector missions")
+        # Find or create the missions group
+        mission_groups: list[dict] = self.mir_api.get_mission_groups()
+        group = next(
+            (x for x in mission_groups if x["name"] == MIR_INORBIT_MISSIONS_GROUP_NAME), None
+        )
+        self.missions_group_id = group["guid"] if group is not None else str(uuid.uuid4())
+        if group is None:
+            self._logger.info(f"Creating mission group '{MIR_INORBIT_MISSIONS_GROUP_NAME}'")
+            group = self.mir_api.create_mission_group(
+                feature=".",
+                icon=".",
+                name=MIR_INORBIT_MISSIONS_GROUP_NAME,
+                priority=0,
+                guid=self.missions_group_id,
+            )
+            self._logger.info(f"Mission group created with guid '{self.missions_group_id}'")
+        else:
+            self._logger.info(
+                f"Found mission group '{MIR_INORBIT_MISSIONS_GROUP_NAME}' with "
+                f"guid '{self.missions_group_id}'"
+            )
+
+    def cleanup_connector_missions(self):
+        """Delete the missions group created at startup"""
+        self._logger.info("Cleaning up connector missions")
+        self._logger.info(f"Deleting missions group {self.missions_group_id}")
+        self.mir_api.delete_mission_group(self.missions_group_id)

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -273,7 +273,8 @@ class Mir100Connector(Connector):
         param_values = {
             "x": float(pose["x"]),
             "y": float(pose["y"]),
-            "theta": math.degrees(float(pose["yaw"])),
+            "orientation": math.degrees(float(pose["theta"])),
+            "distance_threshold": MIR_MOVE_DISTANCE_THRESHOLD,
         }
         if connector_type == "MiR100" and firmware_version == "v2":
             param_values["retries"] = 5

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -358,9 +358,9 @@ class Mir100Connector(Connector):
             missions_queue = self.mir_api.get_missions_queue()
             # Do not delete definitions of missions that are pending or executing
             protected_mission_defs = [
-                self.mir_api.get_mission(mission["url"].split("/")[-1])["mission_id"]
+                self.mir_api.get_mission(mission["id"])["mission_id"]
                 for mission in missions_queue
-                if mission["state"] in ["Pending", "Executing"]
+                if mission["state"].lower() in ["pending", "executing"]
             ]
             # Delete the missions definitions in the temporary group that are not
             # associated to pending or executing missions

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -87,6 +87,14 @@ class MirApiV2(MirApiBaseClass):
         groups = self._get(mission_groups_api_url, self.api_session).json()
         return groups
 
+    def get_mission_group_missions(self, mission_group_id: str):
+        """Get available missions for a mission group"""
+        mission_group_api_url = (
+            f"{self.mir_api_base_url}/{MISSION_GROUPS_ENDPOINT_V2}/{mission_group_id}/missions"
+        )
+        missions = self._get(mission_group_api_url, self.api_session).json()
+        return missions
+
     def create_mission_group(self, feature, icon, name, priority, **kwargs):
         """Create a new mission group"""
         mission_groups_api_url = f"{self.mir_api_base_url}/{MISSION_GROUPS_ENDPOINT_V2}"
@@ -104,6 +112,15 @@ class MirApiV2(MirApiBaseClass):
         mission_group_api_url = f"{self.mir_api_base_url}/{MISSION_GROUPS_ENDPOINT_V2}/{group_id}"
         self._delete(
             mission_group_api_url,
+            self.api_session,
+            headers={"Content-Type": "application/json"},
+        )
+
+    def delete_mission_definition(self, mission_id):
+        """Delete a mission definition"""
+        mission_api_url = f"{self.mir_api_base_url}/{MISSIONS_ENDPOINT_V2}/{mission_id}"
+        self._delete(
+            mission_api_url,
             self.api_session,
             headers={"Content-Type": "application/json"},
         )
@@ -168,6 +185,12 @@ class MirApiV2(MirApiBaseClass):
         response = self._get(actions_api_url, self.api_session)
         actions = response.json()
         return actions
+
+    def get_missions_queue(self):
+        """Returns all missions in the missions queue"""
+        missions_api_url = f"{self.mir_api_base_url}/{MISSION_QUEUE_ENDPOINT_V2}"
+        response = self._get(missions_api_url, self.api_session)
+        return response.json()
 
     def get_executing_mission_id(self):
         """Returns the id of the mission being currently executed by the robot"""

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -19,6 +19,7 @@ API_V2_CONTEXT_URL = "/api/v2.0.0"
 # Endpoints
 METRICS_ENDPOINT_V2 = "metrics"
 MISSION_QUEUE_ENDPOINT_V2 = "mission_queue"
+MISSION_GROUPS_ENDPOINT_V2 = "mission_groups"
 MISSIONS_ENDPOINT_V2 = "missions"
 STATUS_ENDPOINT_V2 = "status"
 
@@ -79,6 +80,63 @@ class MirApiV2(MirApiBaseClass):
             for sample in family.samples:
                 samples[sample.name] = sample.value
         return samples
+
+    def get_mission_groups(self):
+        """Get available mission groups"""
+        mission_groups_api_url = f"{self.mir_api_base_url}/{MISSION_GROUPS_ENDPOINT_V2}"
+        groups = self._get(mission_groups_api_url, self.api_session).json()
+        return groups
+
+    def create_mission_group(self, feature, icon, name, priority, **kwargs):
+        """Create a new mission group"""
+        mission_groups_api_url = f"{self.mir_api_base_url}/{MISSION_GROUPS_ENDPOINT_V2}"
+        group = {"feature": feature, "icon": icon, "name": name, "priority": priority, **kwargs}
+        response = self._post(
+            mission_groups_api_url,
+            self.api_session,
+            headers={"Content-Type": "application/json"},
+            json=group,
+        )
+        return response.json()
+
+    def delete_mission_group(self, group_id):
+        """Delete a mission group"""
+        mission_group_api_url = f"{self.mir_api_base_url}/{MISSION_GROUPS_ENDPOINT_V2}/{group_id}"
+        self._delete(
+            mission_group_api_url,
+            self.api_session,
+            headers={"Content-Type": "application/json"},
+        )
+
+    def create_mission(self, group_id, name, **kwargs):
+        """Create a mission"""
+        mission_api_url = f"{self.mir_api_base_url}/{MISSIONS_ENDPOINT_V2}"
+        mission = {"group_id": group_id, "name": name, **kwargs}
+        response = self._post(
+            mission_api_url,
+            self.api_session,
+            headers={"Content-Type": "application/json"},
+            json=mission,
+        )
+        return response.json()
+
+    def add_action_to_mission(self, action_type, mission_id, parameters, priority, **kwargs):
+        """Add an action to an existing mission"""
+        action_api_url = f"{self.mir_api_base_url}/{MISSIONS_ENDPOINT_V2}/{mission_id}/actions"
+        action = {
+            "mission_id": mission_id,
+            "action_type": action_type,
+            "parameters": parameters,
+            "priority": priority,
+            **kwargs,
+        }
+        response = self._post(
+            action_api_url,
+            self.api_session,
+            headers={"Content-Type": "application/json"},
+            json=action,
+        )
+        return response.json()
 
     def get_mission(self, mission_queue_id):
         """Queries a mission using the mission_queue/{mission_id} endpoint"""
@@ -179,6 +237,7 @@ class MirApiV2(MirApiBaseClass):
 
     def send_waypoint(self, pose):
         """Receives a pose and sends a request to command the robot to navigate to the waypoint"""
+        # Note: This method is deprecated. Prefer creating one-off missions with move actions.
         self.logger.info("Sending waypoint")
         orientation_degs = math.degrees(float(pose["theta"]))
         parameters = {

--- a/mir_connector/inorbit_mir_connector/tests/test_config_validation.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_config_validation.py
@@ -13,7 +13,7 @@ def example_configuration_dict():
     return {
         "inorbit_robot_key": "1234567890",
         "location_tz": "America/Los_Angeles",
-        "connector_type": "mir100",
+        "connector_type": "MiR100",
         "log_level": "INFO",
         "user_scripts": {"path": "/path/to/scripts", "env_vars": {"name": "value"}},
     }
@@ -31,6 +31,7 @@ def example_mir100_configuration_dict(example_configuration_dict):
             "mir_username": "admin",
             "mir_password": "admin",
             "mir_api_version": "v2.0",
+            "mir_firmware_version": "v2",
             "enable_mission_tracking": True,
         },
     }

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -347,3 +347,60 @@ def test_connector_loop(connector):
     assert not connector._robot_session.publish_pose.called
     assert not connector._robot_session.publish_key_values.called
     assert not connector._robot_session.publish_odometry.called
+
+
+def test_garbage_collection_calllback(connector, callback_kwargs):
+    connector.start_missions_garbage_collector = Mock()
+    # Missions in the temporary group
+    connector.tmp_missions_group_id = "tmp_group_id"
+    connector.mir_api.get_mission_group_missions.return_value = [
+        {
+            "url": "/v2.0.0/missions/72003359-6445-419c-85fb-df5576a9ce2e",
+            "guid": "72003359-6445-419c-85fb-df5576a9ce2e",
+            "name": "Move to waypoint",
+        },
+        {
+            "url": "/v2.0.0/missions/c0a17f65-39f1-4b10-8fee-77dfe1470ac1",
+            "guid": "c0a17f65-39f1-4b10-8fee-77dfe1470ac1",
+            "name": "Move to waypoint",
+        },
+        {
+            "url": "/v2.0.0/missions/d871d686-9006-4ddf-af78-bac9a22ddb53",
+            "guid": "d871d686-9006-4ddf-af78-bac9a22ddb53",
+            "name": "Move to waypoint",
+        },
+        {
+            "url": "/v2.0.0/missions/not_in_queue_so_safe_to_delete",
+            "guid": "not_in_queue_so_safe_to_delete",
+            "name": "Move to waypoint",
+        },
+    ]
+    # Missions in the queue
+    connector.mir_api.get_missions_queue.return_value = [
+        {"url": "/v2.0.0/mission_queue/1", "state": "Abort", "id": 1},
+        {"url": "/v2.0.0/mission_queue/2", "state": "Finalized", "id": 2},
+        {"url": "/v2.0.0/mission_queue/3", "state": "Pending", "id": 3},
+        {"url": "/v2.0.0/mission_queue/4", "state": "Executing", "id": 4},
+    ]
+    # Definition of missions in the queue
+    defs = {
+        1: {
+            "mission_id": "72003359-6445-419c-85fb-df5576a9ce2e",
+            "id": 1,
+        },  # Would be safe to delete
+        2: {"mission_id": "not_in_tmp_group", "id": 2},  # Should not be deleted
+        3: {"mission_id": "d871d686-9006-4ddf-af78-bac9a22ddb53", "id": 3},  # Not safe to delete
+        4: {"mission_id": "c0a17f65-39f1-4b10-8fee-77dfe1470ac1", "id": 4},  # Not safe to delete
+    }
+    connector.mir_api.get_mission.side_effect = lambda id: defs[id]
+    connector._missions_gc_callback(..., ...)
+    # Only deletes the mission definition of mission with id 1
+    # and mission that is not in the queue
+    connector.mir_api.delete_mission_definition.assert_any_call(
+        "72003359-6445-419c-85fb-df5576a9ce2e"
+    )
+    connector.mir_api.delete_mission_definition.assert_any_call("not_in_queue_so_safe_to_delete")
+    print(connector.mir_api.delete_mission_definition.call_args_list)
+    assert connector.mir_api.delete_mission_definition.call_count == 2
+    # Restarts automatically
+    connector.start_missions_garbage_collector.assert_called_once()

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -200,10 +200,10 @@ def test_command_callback_state(connector, callback_kwargs):
 
 def test_command_callback_nav_goal(connector, callback_kwargs):
     callback_kwargs["command_name"] = "navGoal"
-    callback_kwargs["args"] = [{"x": "1", "y": "2", "yaw": "3.14"}]
+    callback_kwargs["args"] = [{"x": "1", "y": "2", "theta": "3.14"}]
     connector.send_waypoint_over_missions = Mock()
     connector._inorbit_command_handler(**callback_kwargs)
-    connector.send_waypoint_over_missions.assert_called_with({"x": "1", "y": "2", "yaw": "3.14"})
+    connector.send_waypoint_over_missions.assert_called_with({"x": "1", "y": "2", "theta": "3.14"})
 
 
 def test_send_waypoint_over_missions(connector, monkeypatch):
@@ -211,7 +211,7 @@ def test_send_waypoint_over_missions(connector, monkeypatch):
     # Test MiR100 firmware v2
     connector.config.connector_type = "MiR100"
     connector.config.connector_config.mir_firmware_version = "v2"
-    connector.send_waypoint_over_missions({"x": "1", "y": "2", "yaw": "0"})
+    connector.send_waypoint_over_missions({"x": "1", "y": "2", "theta": "0"})
     connector.mir_api.create_mission.assert_called_once()
     connector.mir_api.add_action_to_mission.assert_called_once_with(
         action_type="move_to_position",
@@ -219,7 +219,8 @@ def test_send_waypoint_over_missions(connector, monkeypatch):
         parameters=[
             {"value": 1.0, "input_name": None, "guid": "uuid", "id": "x"},
             {"value": 2.0, "input_name": None, "guid": "uuid", "id": "y"},
-            {"value": 0, "input_name": None, "guid": "uuid", "id": "theta"},
+            {"value": 0, "input_name": None, "guid": "uuid", "id": "orientation"},
+            {"value": 0.1, "input_name": None, "guid": "uuid", "id": "distance_threshold"},
             {"value": 5, "input_name": None, "guid": "uuid", "id": "retries"},
         ],
         priority=1,
@@ -229,7 +230,7 @@ def test_send_waypoint_over_missions(connector, monkeypatch):
     # Test MiR100 firmware v3
     connector.config.connector_type = "MiR250"
     connector.config.connector_config.mir_firmware_version = "v3"
-    connector.send_waypoint_over_missions({"x": "1", "y": "2", "yaw": "0"})
+    connector.send_waypoint_over_missions({"x": "1", "y": "2", "theta": "0"})
     connector.mir_api.create_mission.assert_called_once()
     connector.mir_api.add_action_to_mission.assert_called_once_with(
         action_type="move_to_position",
@@ -237,7 +238,8 @@ def test_send_waypoint_over_missions(connector, monkeypatch):
         parameters=[
             {"value": 1.0, "input_name": None, "guid": "uuid", "id": "x"},
             {"value": 2.0, "input_name": None, "guid": "uuid", "id": "y"},
-            {"value": 0, "input_name": None, "guid": "uuid", "id": "theta"},
+            {"value": 0, "input_name": None, "guid": "uuid", "id": "orientation"},
+            {"value": 0.1, "input_name": None, "guid": "uuid", "id": "distance_threshold"},
             {"value": 60.0, "input_name": None, "guid": "uuid", "id": "blocked_path_timeout"},
         ],
         priority=1,

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -6,6 +6,7 @@ import math
 import time
 import pytest
 import websocket
+import uuid
 from unittest.mock import MagicMock, Mock, call
 from inorbit_edge.robot import RobotSession
 from inorbit_mir_connector.src.mir_api import MirApiV2
@@ -27,7 +28,7 @@ def connector(monkeypatch, tmp_path):
             inorbit_robot_key="robot_key",
             location_tz="UTC",
             log_level="INFO",
-            connector_type="mir100",
+            connector_type="MiR100",
             connector_version="0.1.0",
             connector_config={
                 "mir_host_address": "example.com",
@@ -38,6 +39,7 @@ def connector(monkeypatch, tmp_path):
                 "mir_username": "user",
                 "mir_password": "pass",
                 "mir_api_version": "v2.0",
+                "mir_firmware_version": "v2",
                 "enable_mission_tracking": False,
             },
             user_scripts_dir=tmp_path,
@@ -128,7 +130,7 @@ def test_enable_ws_flag(monkeypatch, tmp_path):
         inorbit_robot_key="robot_key",
         location_tz="UTC",
         log_level="INFO",
-        connector_type="mir100",
+        connector_type="MiR100",
         connector_version="0.1.0",
         connector_config={
             "mir_username": "user",
@@ -139,6 +141,7 @@ def test_enable_ws_flag(monkeypatch, tmp_path):
             "mir_ws_port": 9090,
             "mir_use_ssl": False,
             "mir_api_version": "v2.0",
+            "mir_firmware_version": "v2",
             "enable_mission_tracking": False,
         },
         user_scripts_dir=tmp_path,
@@ -151,7 +154,7 @@ def test_enable_ws_flag(monkeypatch, tmp_path):
         inorbit_robot_key="robot_key",
         location_tz="UTC",
         log_level="INFO",
-        connector_type="mir100",
+        connector_type="MiR100",
         connector_version="0.1.0",
         connector_config={
             "mir_username": "user",
@@ -162,6 +165,7 @@ def test_enable_ws_flag(monkeypatch, tmp_path):
             "mir_ws_port": 9090,
             "mir_use_ssl": False,
             "mir_api_version": "v2.0",
+            "mir_firmware_version": "v2",
             "enable_mission_tracking": False,
         },
         user_scripts_dir=tmp_path,
@@ -196,11 +200,49 @@ def test_command_callback_state(connector, callback_kwargs):
 
 def test_command_callback_nav_goal(connector, callback_kwargs):
     callback_kwargs["command_name"] = "navGoal"
-    callback_kwargs["args"] = [{"x": "1", "y": "2", "theta": "3.14"}]
+    callback_kwargs["args"] = [{"x": "1", "y": "2", "yaw": "3.14"}]
+    connector.send_waypoint_over_missions = Mock()
     connector._inorbit_command_handler(**callback_kwargs)
-    assert connector.mir_api.send_waypoint.call_args_list == [
-        call({"x": "1", "y": "2", "theta": "3.14"})
-    ]
+    connector.send_waypoint_over_missions.assert_called_with({"x": "1", "y": "2", "yaw": "3.14"})
+
+
+def test_send_waypoint_over_missions(connector, monkeypatch):
+    monkeypatch.setattr(uuid, "uuid4", Mock(return_value="uuid"))
+    # Test MiR100 firmware v2
+    connector.config.connector_type = "MiR100"
+    connector.config.connector_config.mir_firmware_version = "v2"
+    connector.send_waypoint_over_missions({"x": "1", "y": "2", "yaw": "0"})
+    connector.mir_api.create_mission.assert_called_once()
+    connector.mir_api.add_action_to_mission.assert_called_once_with(
+        action_type="move_to_position",
+        mission_id="uuid",
+        parameters=[
+            {"value": 1.0, "input_name": None, "guid": "uuid", "id": "x"},
+            {"value": 2.0, "input_name": None, "guid": "uuid", "id": "y"},
+            {"value": 0, "input_name": None, "guid": "uuid", "id": "theta"},
+            {"value": 5, "input_name": None, "guid": "uuid", "id": "retries"},
+        ],
+        priority=1,
+    )
+    connector.mir_api.queue_mission.assert_called_once_with("uuid")
+    connector.mir_api.reset_mock()
+    # Test MiR100 firmware v3
+    connector.config.connector_type = "MiR250"
+    connector.config.connector_config.mir_firmware_version = "v3"
+    connector.send_waypoint_over_missions({"x": "1", "y": "2", "yaw": "0"})
+    connector.mir_api.create_mission.assert_called_once()
+    connector.mir_api.add_action_to_mission.assert_called_once_with(
+        action_type="move_to_position",
+        mission_id="uuid",
+        parameters=[
+            {"value": 1.0, "input_name": None, "guid": "uuid", "id": "x"},
+            {"value": 2.0, "input_name": None, "guid": "uuid", "id": "y"},
+            {"value": 0, "input_name": None, "guid": "uuid", "id": "theta"},
+            {"value": 60.0, "input_name": None, "guid": "uuid", "id": "blocked_path_timeout"},
+        ],
+        priority=1,
+    )
+    connector.mir_api.queue_mission.assert_called_once_with("uuid")
 
 
 def test_command_callback_inorbit_messages(connector, callback_kwargs):
@@ -211,7 +253,7 @@ def test_command_callback_inorbit_messages(connector, callback_kwargs):
         assert connector.mir_api.set_state.call_args == call(code)
 
 
-def test_connector_loop(connector, monkeypatch):
+def test_connector_loop(connector):
     connector.mission_tracking.report_mission = Mock()
 
     def run_loop_once():

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -19,6 +19,7 @@ requirements = [
     "pydantic>=2.5",
     "psutil==5.9",
     "websocket-client==1.7.0",
+    "uuid==1.30",
 ]
 
 test_requirements = [


### PR DESCRIPTION
## Description

Enable waypoint navigation using one-off missions. Creates and removes a temporary missions group, which in the future can be used for executing other times of missions.

Also makes explicit the support for MiR250 models with firmware version v3
