### PR TITLE
MiR Docker build actions

### DIFF
--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -110,12 +110,15 @@ jobs:
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: mir_connector/
           file: ./docker/Dockerfile
-          push: true
+          push: false
           tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}
 
       # - name: Generate artifact attestation

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-    # environment: release # TODO: reactivate this. It makes actions require an approval to run
+    environment: release
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -60,7 +60,7 @@ jobs:
           cd  mir_connector
           pytest
 
-  publish:
+  publish-pypi:
     if: contains(github.event.head_commit.message, 'Bump version')
     needs: [test, lint]
     runs-on: ubuntu-latest
@@ -90,3 +90,38 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: mir_connector/dist/
+
+  docker-build:
+    # needs: [test, lint]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    environment: release
+    permissions:
+        id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to Google Artifact Registry
+        if: contains(github.event.head_commit.message, 'Bump version')
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: mir_connector/
+          file: ./docker/Dockerfile
+          push: true #  ${{ contains(github.event.head_commit.message, 'Bump version') }}
+          tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}
+
+      # - name: Generate artifact attestation
+      #   uses: actions/attest-build-provenance@v1
+      #   with:
+      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+      #     subject-digest: ${{ steps.push.outputs.digest }}
+      #     push-to-registry: true

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -92,13 +92,12 @@ jobs:
           packages-dir: mir_connector/dist/
 
   docker-build:
-    # needs: [test, lint]
+    #  ${{ contains(github.event.head_commit.message, 'Bump version') }} # TODO: reenable
+    # needs: [test, lint] # TODO: reenable
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-    environment: release
-    permissions:
-        id-token: write
+    # environment: release # TODO: reactivate this. It makes actions require an approval to run
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -116,7 +115,7 @@ jobs:
         with:
           context: mir_connector/
           file: ./docker/Dockerfile
-          push: true #  ${{ contains(github.event.head_commit.message, 'Bump version') }}
+          push: true
           tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}
 
       # - name: Generate artifact attestation

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -13,83 +13,83 @@ on:
       - mir_connector/**
 
 jobs:
-  lint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
-        os: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Lint with flake8
-        uses: py-actions/flake8@v2
-        with:
-          path: mir_connector
-          max-line-length: 100
-      - name: Check with black
-        uses: psf/black@stable
-        with:
-          version: "~= 23.0"
-          src: mir_connector
-          options: "--diff --check --line-length=100"
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          cd mir_connector
-          python -m pip install --upgrade pip
-          python -m pip install -e .["test"]
-      - name: Test with pytest
-        run: |
-          cd  mir_connector
-          pytest
+  # lint:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ["3.11"]
+  #       os: [ubuntu-latest]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Lint with flake8
+  #       uses: py-actions/flake8@v2
+  #       with:
+  #         path: mir_connector
+  #         max-line-length: 100
+  #     - name: Check with black
+  #       uses: psf/black@stable
+  #       with:
+  #         version: "~= 23.0"
+  #         src: mir_connector
+  #         options: "--diff --check --line-length=100"
+  # test:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ["3.10", "3.11", "3.12"]
+  #       os: [ubuntu-latest, windows-latest, macOS-latest]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install dependencies
+  #       run: |
+  #         cd mir_connector
+  #         python -m pip install --upgrade pip
+  #         python -m pip install -e .["test"]
+  #     - name: Test with pytest
+  #       run: |
+  #         cd  mir_connector
+  #         pytest
 
-  publish-pypi:
-    if: contains(github.event.head_commit.message, 'Bump version')
-    needs: [test, lint]
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-    environment: release
-    permissions:
-        id-token: write
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.11"
-      - name: Install Dependencies
-        run: |
-          cd mir_connector
-          python -m pip install --upgrade pip
-          python -m pip install .[dev]
-      - name: Build Package
-        run: |
-          cd mir_connector
-          python -m build --sdist
-          twine check dist/*
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: mir_connector/dist/
+  # publish-pypi:
+  #   if: contains(github.event.head_commit.message, 'Bump version')
+  #   needs: [test, lint]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: true
+  #   environment: release
+  #   permissions:
+  #       id-token: write
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v3
+  #       with:
+  #         python-version: "3.11"
+  #     - name: Install Dependencies
+  #       run: |
+  #         cd mir_connector
+  #         python -m pip install --upgrade pip
+  #         python -m pip install .[dev]
+  #     - name: Build Package
+  #       run: |
+  #         cd mir_connector
+  #         python -m build --sdist
+  #         twine check dist/*
+  #     - name: Publish to PyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         repository-url: https://test.pypi.org/legacy/
+  #         packages-dir: mir_connector/dist/
 
   docker-build:
     #  ${{ contains(github.event.head_commit.message, 'Bump version') }} # TODO: reenable
@@ -102,27 +102,29 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set variables
+        run: |
+          CONNECTOR_VERSION=$(grep -oP '(?<=current_version = ")[^"]*' mir_connector/.bumpversion.toml)
+          echo "CONNECTOR_VERSION=$CONNECTOR_VERSION" >> $GITHUB_ENV
+      
+      - name: Show version
+        run: |
+          echo ${{ env.CONNECTOR_VERSION }}
 
-      - name: Login to Google Artifact Registry
-        uses: docker/login-action@v3
-        with:
-          registry: us-central1-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GAR_JSON_KEY }}
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: "{{defaultContext}}:mir_connector"
-          file: ./docker/Dockerfile
-          push: false
-          tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}
-
-      # - name: Generate artifact attestation
-      #   uses: actions/attest-build-provenance@v1
+      # - name: Login to Google Artifact Registry
+      #   uses: docker/login-action@v3
       #   with:
-      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
-      #     subject-digest: ${{ steps.push.outputs.digest }}
-      #     push-to-registry: true
+      #     registry: us-central1-docker.pkg.dev
+      #     username: _json_key
+      #     password: ${{ secrets.GAR_JSON_KEY }}
+
+      # - name: Build and push
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     context: "{{defaultContext}}:mir_connector"
+      #     file: ./docker/Dockerfile
+      #     push: false
+      #     tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -102,16 +102,15 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Google Artifact Registry
-        if: contains(github.event.head_commit.message, 'Bump version')
         uses: docker/login-action@v3
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -13,87 +13,87 @@ on:
       - mir_connector/**
 
 jobs:
-  # lint:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version: ["3.11"]
-  #       os: [ubuntu-latest]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Lint with flake8
-  #       uses: py-actions/flake8@v2
-  #       with:
-  #         path: mir_connector
-  #         max-line-length: 100
-  #     - name: Check with black
-  #       uses: psf/black@stable
-  #       with:
-  #         version: "~= 23.0"
-  #         src: mir_connector
-  #         options: "--diff --check --line-length=100"
-  # test:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version: ["3.10", "3.11", "3.12"]
-  #       os: [ubuntu-latest, windows-latest, macOS-latest]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install dependencies
-  #       run: |
-  #         cd mir_connector
-  #         python -m pip install --upgrade pip
-  #         python -m pip install -e .["test"]
-  #     - name: Test with pytest
-  #       run: |
-  #         cd  mir_connector
-  #         pytest
+  lint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Lint with flake8
+        uses: py-actions/flake8@v2
+        with:
+          path: mir_connector
+          max-line-length: 100
+      - name: Check with black
+        uses: psf/black@stable
+        with:
+          version: "~= 23.0"
+          src: mir_connector
+          options: "--diff --check --line-length=100"
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          cd mir_connector
+          python -m pip install --upgrade pip
+          python -m pip install -e .["test"]
+      - name: Test with pytest
+        run: |
+          cd  mir_connector
+          pytest
 
-  # publish-pypi:
-  #   if: contains(github.event.head_commit.message, 'Bump version')
-  #   needs: [test, lint]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: true
-  #   environment: release
-  #   permissions:
-  #       id-token: write
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.11"
-  #     - name: Install Dependencies
-  #       run: |
-  #         cd mir_connector
-  #         python -m pip install --upgrade pip
-  #         python -m pip install .[dev]
-  #     - name: Build Package
-  #       run: |
-  #         cd mir_connector
-  #         python -m build --sdist
-  #         twine check dist/*
-  #     - name: Publish to PyPI
-  #       uses: pypa/gh-action-pypi-publish@release/v1
-  #       with:
-  #         repository-url: https://test.pypi.org/legacy/
-  #         packages-dir: mir_connector/dist/
+  publish-pypi:
+    if: contains(github.event.head_commit.message, 'Bump version')
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    environment: release
+    permissions:
+        id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.11"
+      - name: Install Dependencies
+        run: |
+          cd mir_connector
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+      - name: Build Package
+        run: |
+          cd mir_connector
+          python -m build --sdist
+          twine check dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: mir_connector/dist/
 
   docker-build:
-    #  ${{ contains(github.event.head_commit.message, 'Bump version') }} # TODO: reenable
-    # needs: [test, lint] # TODO: reenable
+    if: ${{ contains(github.event.head_commit.message, 'Bump version') }}
+    needs: [test, lint]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -91,7 +91,7 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: mir_connector/dist/
 
-  docker-build:
+  publish-docker:
     if: ${{ contains(github.event.head_commit.message, 'Bump version') }}
     needs: [test, lint]
     runs-on: ubuntu-latest

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -123,5 +123,5 @@ jobs:
         with:
           context: "{{defaultContext}}:mir_connector"
           file: ./docker/Dockerfile
-          push: false
+          push: true
           tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:${{ env.CONNECTOR_VERSION }}

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: mir_connector/
+          context: "{{defaultContext}}:mir_connector"
           file: ./docker/Dockerfile
           push: false
           tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/mir_workflows.yml
+++ b/.github/workflows/mir_workflows.yml
@@ -102,29 +102,26 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Set variables
+      - name: Set version environment variable
         run: |
           CONNECTOR_VERSION=$(grep -oP '(?<=current_version = ")[^"]*' mir_connector/.bumpversion.toml)
           echo "CONNECTOR_VERSION=$CONNECTOR_VERSION" >> $GITHUB_ENV
-      
-      - name: Show version
-        run: |
-          echo ${{ env.CONNECTOR_VERSION }}
+          echo "CONNECTOR_VERSION is '$CONNECTOR_VERSION'"
 
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      # - name: Login to Google Artifact Registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: us-central1-docker.pkg.dev
-      #     username: _json_key
-      #     password: ${{ secrets.GAR_JSON_KEY }}
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GAR_JSON_KEY }}
 
-      # - name: Build and push
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     context: "{{defaultContext}}:mir_connector"
-      #     file: ./docker/Dockerfile
-      #     push: false
-      #     tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:latest # ${{ steps.meta.outputs.tags }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:mir_connector"
+          file: ./docker/Dockerfile
+          push: false
+          tags: us-central1-docker.pkg.dev/inorbit-integrations/connectors/mir_connector:${{ env.CONNECTOR_VERSION }}

--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -149,7 +149,7 @@ bump-my-version bump minor --dry-run --verbose
 
 ### Build and publish the package
 
-New releases are built and published to PyPi automatically by GitHub Actions when a new version bump commit is pushed.
+New releases are built and published to PyPi and the Docker repository automatically by GitHub Actions when a new version bump commit is pushed.
 
 > _Note:_ The message of the last commit must contain "Bump version" for the publish job to run. e.g. "Bump version: 1.0.0 -> 1.0.1"
 
@@ -161,5 +161,7 @@ python -m build --sdist # Build the package
 twine check dist/* # Run checks
 twine upload --repository testpypi dist/* # Upload to test PyPI. $HOME/.pypirc should exist and contain the api tokens. See https://pypi.org/help/#apitoken
 ```
+
+To manually push the Docker image run `./docker/build.sh --push`
 
 ![Powered by InOrbit](../assets/inorbit_github_footer.png)


### PR DESCRIPTION
### Description

Automatic build and push of the MiR docker image. A succesful run of the `publish-docker` job can be found [here](https://github.com/inorbit-ai/inorbit-robot-connectors/actions/runs/11975098920/job/33387683789?pr=30), where it is run without the version bump condition and the `lint` and `test` dependencies.