### PR TITLE
MiR: Join execution loop

### DIFF
--- a/mir_connector/inorbit_mir_connector/mir100_start.py
+++ b/mir_connector/inorbit_mir_connector/mir100_start.py
@@ -65,6 +65,7 @@ def start():
     mir_connector = Mir100Connector(robot_id, mir_config)
     try:
         mir_connector.start()
+        mir_connector.join()
     except KeyboardInterrupt:
         LOGGER.info("Received SIGINT, stopping connector")
         mir_connector.stop()

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 requirements = [
     "requests>=2.31,<3.0",
     "inorbit-edge[video]>=1.17",
-    "inorbit-connector>=0.3.0",
+    "inorbit-connector==0.4.0",
     "prometheus-client>=0.14.1",
     "pytz>=2022.7",
     # NOTE: both pyyaml and ruamel.yaml packages are included here. Otherwise, the


### PR DESCRIPTION
## Description

Join the execution loop of the connector, allowing it to be stopped gracefully.

Requires https://github.com/inorbit-ai/inorbit-connector-python/pull/12 (unreleased)

## Demo

Console output:

```
...
INFO:inorbit_connector.connector:Updating map 20f762ff-5e0a-11ee-abc8-0001299981c4 with new pose.
^CINFO:inorbit_mir_connector.mir100_start:Received SIGINT, stopping connector
INFO:inorbit_connector.connector:Cleaning up connector missions
INFO:inorbit_connector.connector:Deleting missions group b6a3a55c-26a6-4a74-b6cd-1955851c1f03
INFO:inorbit_connector.connector:Updating map 20f762ff-5e0a-11ee-abc8-0001299981c4 with new pose.
ERROR:inorbit_connector.connector:Map 20f762ff-5e0a-11ee-abc8-0001299981c4 not found in the current configuration. Map message will not be sent.
INFO:RobotSession:Ending robot session
INFO:RobotSession:Publishing status 0. ret = (0, 26).
INFO:RobotSession:Robot status '0' published: 1.
INFO:RobotSession:Waiting for MQTT connection state '_is_disconnected' ...
INFO:RobotSession:Disconnected from MQTT broker
```