### PR TITLE
Upload `connector_version` value

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -15,6 +15,7 @@ from .mir_api import MirApiV2
 from .mir_api import MirWebSocketV2
 from .mission import MirInorbitMissionTracking
 from ..config.mir100_model import MiR100Config
+from .. import __version__
 
 
 # Available MiR states to select via actions
@@ -113,8 +114,8 @@ class Mir100Connector(Connector):
                 - `metadata` is reserved for the future and will contains additional
                 information about the received command request.
         """
+        self._logger.info(f"Received '{command_name}'!. {args}")
         if command_name == COMMAND_CUSTOM_COMMAND:
-            self._logger.info(f"Received '{command_name}'!. {args}")
             if len(args) < 2:
                 self._logger.error("Invalid number of arguments: ", args)
                 options["result_function"](
@@ -194,7 +195,6 @@ class Mir100Connector(Connector):
             # Return '0' for success
             options["result_function"]("0")
         elif command_name == COMMAND_NAV_GOAL:
-            self._logger.info(f"Received '{command_name}'!. {args}")
             pose = args[0]
             self.send_waypoint_over_missions(pose)
         elif command_name == COMMAND_MESSAGE:
@@ -264,6 +264,7 @@ class Mir100Connector(Connector):
         # publish key values
         # TODO(Elvio): Move key values to a "values.py" and represent them with constants
         key_values = {
+            "connector_version": __version__,
             "battery percent": self.status["battery_percentage"],
             "battery_time_remaining": self.status["battery_time_remaining"],
             "uptime": self.status["uptime"],

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -11,11 +11,11 @@ from inorbit_connector.connector import Connector
 from inorbit_edge.robot import COMMAND_CUSTOM_COMMAND
 from inorbit_edge.robot import COMMAND_MESSAGE
 from inorbit_edge.robot import COMMAND_NAV_GOAL
+from inorbit_mir_connector import get_module_version
 from .mir_api import MirApiV2
 from .mir_api import MirWebSocketV2
 from .mission import MirInorbitMissionTracking
 from ..config.mir100_model import MiR100Config
-from .. import __version__
 
 
 # Available MiR states to select via actions
@@ -264,7 +264,7 @@ class Mir100Connector(Connector):
         # publish key values
         # TODO(Elvio): Move key values to a "values.py" and represent them with constants
         key_values = {
-            "connector_version": __version__,
+            "connector_version": get_module_version(),
             "battery percent": self.status["battery_percentage"],
             "battery_time_remaining": self.status["battery_time_remaining"],
             "uptime": self.status["uptime"],

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -12,7 +12,7 @@ from inorbit_edge.robot import RobotSession
 from inorbit_mir_connector.src.mir_api import MirApiV2
 from inorbit_mir_connector.src.connector import Mir100Connector
 from inorbit_mir_connector.config.mir100_model import MiR100Config
-from .. import __version__
+from .. import get_module_version
 
 
 @pytest.fixture
@@ -367,7 +367,7 @@ def test_connector_loop(connector, monkeypatch):
     )
     assert connector._robot_session.publish_key_values.call_args == call(
         {
-            "connector_version": __version__,
+            "connector_version": get_module_version(),
             "battery percent": 93.5,
             "battery_time_remaining": 89725,
             "uptime": 3552693,

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -12,6 +12,7 @@ from inorbit_edge.robot import RobotSession
 from inorbit_mir_connector.src.mir_api import MirApiV2
 from inorbit_mir_connector.src.connector import Mir100Connector
 from inorbit_mir_connector.config.mir100_model import MiR100Config
+from .. import __version__
 
 
 @pytest.fixture
@@ -366,6 +367,7 @@ def test_connector_loop(connector, monkeypatch):
     )
     assert connector._robot_session.publish_key_values.call_args == call(
         {
+            "connector_version": __version__,
             "battery percent": 93.5,
             "battery_time_remaining": 89725,
             "uptime": 3552693,


### PR DESCRIPTION
### 🗒️ Description

Upload the connector version in the key-value pairs. This is useful data to show in InOrbit, as it allows to understand what software version each robot is running.

### 📺 Demo

Using a datasource such as:

```yaml
apiVersion: v0.1
kind: DataSourceDefinition
metadata:
  id: connector_version
  scope: tag/<account id>/<Edge SDK robot tag>
spec:
  label: Connector version
  source:
    keyValue:
      key: connector_version
  timeline: {}
```

The value can be display in InOrbit in a suitable widget, such as the ListData widget:

![image](https://github.com/user-attachments/assets/1c356dae-d087-4988-ab34-b29eac06a68f)
