### PR TITLE
MiR Connector: Allow connector to start disconnected and publish `api_connected` value

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -277,6 +277,9 @@ class Mir100Connector(Connector):
             "mode_text": mode_text,
             "robot_model": self.status["robot_model"],
             "waiting_for": self.mission_tracking.waiting_for_text,
+            # The API connected value tells wether or not the last API call was successful
+            # It is recommended to create a status based on this value and use it for incidents
+            "api_connected": self.mir_api.get_last_api_call_successful(),
         }
         self._logger.debug(f"Publishing key values: {key_values}")
         self._robot_session.publish_key_values(key_values)

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -404,13 +404,11 @@ class Mir100Connector(Connector):
         """Delete the missions group created at startup"""
         with self.tmp_missions_group_id_lock:
             # If the missions group id is None, it means it was not set up and there is nothing to
-            # clean up.
-            # Change its value to indicate it should not be set up, in case there is a running
-            # setup thread
+            # clean up. Change its value to indicate it should not be set up, in case there is a
+            # running setup thread.
             if self.tmp_missions_group_id is None:
                 self.tmp_missions_group_id = ""
                 return
-            # If the missions group was None, it means it was not set up
         self._logger.info("Cleaning up connector missions")
         self._logger.info(f"Deleting missions group {self.tmp_missions_group_id}")
         self.mir_api.delete_mission_group(self.tmp_missions_group_id)

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -223,7 +223,8 @@ class Mir100Connector(Connector):
 
     def _disconnect(self):
         """Disconnect from any external services"""
-        self.cleanup_connector_missions()
+        if self.tmp_missions_group_id:
+            self.cleanup_connector_missions()
         super()._disconnect()
         if self.ws_enabled:
             self.mir_ws.disconnect()
@@ -393,8 +394,6 @@ class Mir100Connector(Connector):
 
     def cleanup_connector_missions(self):
         """Delete the missions group created at startup"""
-        if not self.tmp_missions_group_id:
-            return
         self._logger.info("Cleaning up connector missions")
         self._logger.info(f"Deleting missions group {self.tmp_missions_group_id}")
         self.mir_api.delete_mission_group(self.tmp_missions_group_id)

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
@@ -12,16 +12,13 @@ class MirApiBaseClass(ABC):
     def __init__(self, loglevel):
         self.logger = logging.getLogger(name=self.__class__.__name__)
         self.logger.setLevel(loglevel)
-        self.last_api_call_successful = None
 
     def _handle_status(self, res, request_args):
         """Log and raise an exception if the request failed."""
         try:
             res.raise_for_status()
-            self.set_last_api_call_successful(True)
         except HTTPError as e:
             self.logger.error(f"Error making request: {e}\nArguments: {request_args}")
-            self.set_last_api_call_successful(False)
             raise e
 
     def _get(self, url: str, session: Session, **kwargs) -> Response:
@@ -54,12 +51,6 @@ class MirApiBaseClass(ABC):
         self.logger.debug(f"Response: {res}")
         self._handle_status(res, kwargs)
         return res
-
-    def set_last_api_call_successful(self, success: bool) -> None:
-        self.last_api_call_successful = success
-
-    def get_last_api_call_successful(self) -> bool:
-        return self.last_api_call_successful
 
     @abstractmethod
     def _create_api_session(self) -> Session:

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
@@ -12,13 +12,16 @@ class MirApiBaseClass(ABC):
     def __init__(self, loglevel):
         self.logger = logging.getLogger(name=self.__class__.__name__)
         self.logger.setLevel(loglevel)
+        self.last_api_call_successful = None
 
     def _handle_status(self, res, request_args):
         """Log and raise an exception if the request failed."""
         try:
             res.raise_for_status()
+            self.set_last_api_call_successful(True)
         except HTTPError as e:
             self.logger.error(f"Error making request: {e}\nArguments: {request_args}")
+            self.set_last_api_call_successful(False)
             raise e
 
     def _get(self, url: str, session: Session, **kwargs) -> Response:
@@ -51,6 +54,12 @@ class MirApiBaseClass(ABC):
         self.logger.debug(f"Response: {res}")
         self._handle_status(res, kwargs)
         return res
+
+    def set_last_api_call_successful(self, success: bool) -> None:
+        self.last_api_call_successful = success
+
+    def get_last_api_call_successful(self) -> bool:
+        return self.last_api_call_successful
 
     @abstractmethod
     def _create_api_session(self) -> Session:

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -42,7 +42,10 @@ class MirApiV2(MirApiBaseClass):
         self.mir_username = mir_username
         self.mir_password = mir_password
         self.api_session = self._create_api_session()
-        self.web_session = self._create_web_session()
+
+    def _get_web_session(self) -> requests.Session:
+        if not self.web_session:
+            self.web_session = self._create_web_session()
 
     def _create_api_session(self) -> requests.Session:
         session = requests.Session()
@@ -270,7 +273,7 @@ class MirApiV2(MirApiBaseClass):
             "orientation": orientation_degs,
             "mode": "map-go-to-coordinates",
         }
-        response = self._get(self.mir_base_url, self.web_session, params=parameters)
+        response = self._get(self.mir_base_url, self._get_web_session(), params=parameters)
         self.logger.info(response.text)
 
     def get_status(self):

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -390,7 +390,7 @@ def test_connector_loop(connector, monkeypatch):
     run_loop_once()
     assert not connector._robot_session.publish_pose.called
     assert not connector._robot_session.publish_odometry.called
-    assert connector._robot_session.publish_key_values.called_with({"api_connected": False})
+    connector._robot_session.publish_key_values.assert_called_with({"api_connected": False})
 
 
 def test_missions_garbage_collector(connector):

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -389,8 +389,8 @@ def test_connector_loop(connector, monkeypatch):
     connector._robot_session.reset_mock()
     run_loop_once()
     assert not connector._robot_session.publish_pose.called
-    assert not connector._robot_session.publish_key_values.called
     assert not connector._robot_session.publish_odometry.called
+    assert connector._robot_session.publish_key_values.called_with({"api_connected": False})
 
 
 def test_missions_garbage_collector(connector):

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -47,6 +47,7 @@ def connector(monkeypatch, tmp_path):
         ),
     )
     connector.mir_api = MagicMock()
+    connector.mir_api.get_last_api_call_successful.return_value = True
     connector._robot_session = MagicMock()
     return connector
 
@@ -380,6 +381,7 @@ def test_connector_loop(connector, monkeypatch):
             "mode_text": "Mission",
             "robot_model": "MiR100",
             "waiting_for": "",
+            "api_connected": True,
         }
     )
 

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -20,6 +20,7 @@ requirements = [
     "psutil==5.9",
     "websocket-client==1.7.0",
     "uuid==1.30",
+    "tenacity==9.0.0",
 ]
 
 test_requirements = [


### PR DESCRIPTION
### 🗒️ Description

* Retry initialization of missions group in the background in case the API is not available at startup
* Lazy initialize the API web session (it is rarely used, only for waypoint navigation through deprecated methods)
* Publish `api_connected`, used for indicating the connection health in InOrbit

### 📺 Demo

The demo shows the connector starting and working while the connection to the robot is blocked and unblocked:

https://github.com/user-attachments/assets/2202e121-c72d-45ca-b5db-9c6f5e5e4468
