### PR TITLE
Gausium Connector: InOrbit Actions

### DIFF
--- a/gausium_connector/cac_examples/ActionDefinition.yaml
+++ b/gausium_connector/cac_examples/ActionDefinition.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+# This file defines example actions that trigger specific behavior on the robot.
+# It is recommended to apply them on a hardware tag scope.
+
+# For InOrbit Actions documentation, see:
+# https://developer.inorbit.ai/docs#configuring-action-definitions
+
+# Run a cleaning task on the current map
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: clean-zone-1
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Clean zone 1
+  group: Gausium actions
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: start_cleaning_task
+    - name: path_name
+      type: string
+      value: cleaning_zone_1
+  confirmation:
+    required: true
+  lock: false
+  # Example condition to allow the action to be executed only on specific robots
+  condition:
+    rules:
+    - collections:
+      - <tag_id of the gausium hardware>
+      - <tag_id of the map to clean>
+---
+# Run a cleaning task on a path selected by the user
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: clean-zone-custom
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Clean zone custom
+  group: Gausium actions
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: start_cleaning_task
+    - name: path_name
+      type: string
+      input:
+        control: select
+        values:
+          - cleaning_zone_1
+          - cleaning_zone_2
+  confirmation:
+    required: true
+  lock: false
+---
+# Run a cleaning task controlling all available arguments
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: clean-zone-2
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Clean zone 2
+  group: Gausium actions
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: start_cleaning_task
+    - name: path_name
+      type: string
+      value: path_name
+    # Defaults to the current map
+    - name: map_name
+      type: string
+      value: map_name
+    # Defaults to False
+    - name: loop
+      type: boolean
+      value: true
+    # Defaults to 0
+    - name: loop_count
+      type: number
+      value: 1
+    # Defaults to "InOrbit cleaning task action"
+    - name: task_name
+      type: string
+      value: task_name
+  confirmation:
+    required: true
+  lock: false

--- a/gausium_connector/cac_examples/ActionDefinition.yaml
+++ b/gausium_connector/cac_examples/ActionDefinition.yaml
@@ -96,3 +96,49 @@ spec:
   confirmation:
     required: true
   lock: false
+---
+# Send the robot to a named waypoint
+# This could be a dock, in which case the robot will automatically dock
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: dock
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Dock
+  group: Gausium actions
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: send_to_named_waypoint
+    - name: position_name
+      type: string
+      value: dock_position_name
+  confirmation:
+    required: true
+  lock: false
+---
+# Send the robot to a named waypoint controlling all available arguments
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: send-to-named-waypoint
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Send to named waypoint
+  group: Gausium actions
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: send_to_named_waypoint
+    - name: position_name
+      type: string
+      value: position_name
+    - name: map_name
+      type: string
+      value: map_name
+  confirmation:
+    required: true
+  lock: false

--- a/gausium_connector/cac_examples/RobotFootprint.yaml
+++ b/gausium_connector/cac_examples/RobotFootprint.yaml
@@ -5,6 +5,10 @@
 # This is an example of a RobotFootprint resource, defining the shape of the avatar displayed in
 # navigation widgets.
 # It is recommended to apply it on a hardware tag scope.
+
+# For InOrbit RobotFootprint documentation, see:
+# https://developer.inorbit.ai/docs#configuring-robot-footprint
+
 apiVersion: v0.1
 kind: RobotFootprint
 metadata:

--- a/gausium_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_connector/inorbit_gausium_connector/src/connector.py
@@ -29,6 +29,7 @@ class CustomScripts(Enum):
     """Supported InOrbit CustomScript actions"""
 
     START_CLEANING_TASK = "start_cleaning_task"
+    SEND_TO_NAMED_WAYPOINT = "send_to_named_waypoint"
 
 
 class CommandMessages(Enum):
@@ -226,6 +227,12 @@ class GausiumConnector(Connector):
                 # Name of the task
                 task_name = script_args.get("task_name", "InOrbit cleaning task action")
                 self.robot_api.start_cleaning_task(map_name, path_name, task_name, loop, loop_count)
+            elif script_name == CustomScripts.SEND_TO_NAMED_WAYPOINT.value:
+                # The most important argument
+                position_name = script_args.get("position_name")
+                # Defaults to the current map
+                map_name = script_args.get("map_name")
+                self.robot_api.send_to_named_waypoint(position_name, map_name)
             else:
                 return options["result_function"](
                     "1", f"Custom command '{script_name}' is not implemented"

--- a/gausium_connector/inorbit_gausium_connector/src/robot/robot_api.py
+++ b/gausium_connector/inorbit_gausium_connector/src/robot/robot_api.py
@@ -165,6 +165,11 @@ class GausiumRobotAPI(ABC):
         """Requests the robot to resume whatever it was doing"""
         pass
 
+    @abstractmethod
+    def start_cleaning_task(self, **kwargs) -> bool:
+        """Starts the cleaning task"""
+        pass
+
 
 def flatten(dictionary, parent_key=False, separator="."):
     """
@@ -364,6 +369,34 @@ class GausiumCloudAPI(GausiumRobotAPI):
         """Requests the robot to resume whatever it was doing"""
         # TODO(b-Tomas): Determine which resume command to use
         raise NotImplementedError("Resume command not implemented")
+
+    @override
+    def start_cleaning_task(
+        self,
+        path_name: str,
+        task_name: str = "",
+        map_name: str | None = None,
+        loop: bool = False,
+        loop_count: int = 0,
+    ) -> bool:
+        """Starts the cleaning task.
+
+        Args:
+            path_name (str): Name of the path to start the cleaning task on
+            task_name (str, optional): Name of the task. Defaults to "".
+            map_name (str | None, optional): Name of the map to start the cleaning task on.
+                Defaults to the current map.
+            loop (bool, optional): Whether to loop the task. Defaults to False.
+            loop_count (int, optional): Number of loops. Defaults to 0.
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        if map_name is None:
+            map_name = self._current_map.map_name if self._current_map else None
+        if map_name is None:
+            raise Exception("No current map found to start cleaning task")
+        return self._start_cleaning_task(map_name, path_name, task_name, loop, loop_count)
 
     # ---------- General APIs ----------#
 

--- a/gausium_connector/inorbit_gausium_connector/tests/test_connector.py
+++ b/gausium_connector/inorbit_gausium_connector/tests/test_connector.py
@@ -351,6 +351,23 @@ class TestGausiumConnector:
             "test_map", "vacuum_zone_2", "Custom Task", True, 3
         )
 
+    def test_command_callback_send_to_named_waypoint(self, connector, callback_kwargs):
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["send_to_named_waypoint", ["position_name", "waypoint_1"]]
+        connector._inorbit_command_handler(**callback_kwargs)
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+        connector.robot_api.send_to_named_waypoint.assert_called_once_with("waypoint_1", None)
+        connector.robot_api.send_to_named_waypoint.reset_mock()
+
+        # Test with map name
+        callback_kwargs["args"] = [
+            "send_to_named_waypoint",
+            ["position_name", "waypoint_1", "map_name", "test_map"],
+        ]
+        connector._inorbit_command_handler(**callback_kwargs)
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+        connector.robot_api.send_to_named_waypoint.assert_called_once_with("waypoint_1", "test_map")
+
     def test_execution_loop(self, connector, robot_info, current_position_data, device_status_data):
         # Setup mock return values based on fixtures
         connector.robot_api.pose = {


### PR DESCRIPTION
### 🗒️ Description

Implements support for `start_cleaning_task` and `send_to_named_waypoint`, including examples in Config As Code form.

Note that for docking `send_to_named_waypoint` should be used (see the [example](https://github.com/inorbit-ai/inorbit-robot-connectors/blob/23d9c8e70d23792cc4c6b729e8ae86fe168c2d4f/gausium_connector/cac_examples/ActionDefinition.yaml#L100-L120)).