### PR TITLE
Gausium Connector: Use `mapName` for the published `map_id`

### DIFF
--- a/gausium_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_connector/inorbit_gausium_connector/src/connector.py
@@ -158,7 +158,7 @@ class GausiumConnector(Connector):
                     # Create a new map configuration
                     self.config.maps[frame_id] = MapConfig(
                         file=temp_path,
-                        map_id=map_data.map_id,
+                        map_id=map_data.map_name,
                         frame_id=frame_id,
                         origin_x=map_data.origin_x,
                         origin_y=map_data.origin_y,

--- a/gausium_connector/inorbit_gausium_connector/tests/test_connector.py
+++ b/gausium_connector/inorbit_gausium_connector/tests/test_connector.py
@@ -121,7 +121,7 @@ class TestGausiumConnector:
         # Now using the actual property values from mock_map_data
         mock_map_config.assert_called_once_with(
             file=mock_temp_path,
-            map_id="robot_map",
+            map_id="test_map_name",
             frame_id="new_map",
             origin_x=mock_map_data.origin_x,
             origin_y=mock_map_data.origin_y,


### PR DESCRIPTION
### 🗒️ Description

When publishing a map, use the `mapName` as the map ID, to make the map identifiable in places like the Time Capsule map dropdown menu.

### 📺 Demo

This change is noticeable in the InOrbit [Time Capsule](https://www.inorbit.ai/in-action/timecapsule).

Before

![Screenshot from 2025-03-22 17-01-25](https://github.com/user-attachments/assets/af2e535a-1173-4472-b2f9-15e405679998)

After

![image](https://github.com/user-attachments/assets/e3153907-0cce-4e66-848d-0de378fc3f02)
