### PR TITLE
Gausium Connector: Pause, resume and cancel commands

### DIFF
--- a/gausium_connector/cac_examples/ActionDefinition.yaml
+++ b/gausium_connector/cac_examples/ActionDefinition.yaml
@@ -28,6 +28,8 @@ spec:
   confirmation:
     required: true
   lock: false
+  description: Runs a cleaning task on the current map
+  group: Cleaning tasks
   # Example condition to allow the action to be executed only on specific robots
   condition:
     rules:
@@ -59,6 +61,8 @@ spec:
   confirmation:
     required: true
   lock: false
+  description: Runs a cleaning task on a path selected by the user
+  group: Cleaning tasks
 ---
 # Run a cleaning task controlling all available arguments
 apiVersion: v0.1
@@ -96,7 +100,69 @@ spec:
   confirmation:
     required: true
   lock: false
+  description: Runs a very specific cleaning task
+  group: Cleaning tasks
 ---
+# Pause the current cleaning task
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: pause-cleaning
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Pause Cleaning Task
+  group: Cleaning tasks
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: pause_cleaning_task
+  confirmation:
+    required: true
+  lock: false
+  description: Pauses a currently running cleaning task
+---
+# Resume a paused cleaning task
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: resume-cleaning
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Resume Cleaning Task
+  group: Cleaning tasks
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: resume_cleaning_task
+  confirmation:
+    required: true
+  lock: false
+  description: Resumes a previously paused cleaning task
+---
+# Cancel the current cleaning task
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: cancel-cleaning
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Cancel Cleaning Task
+  group: Cleaning tasks
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: cancel_cleaning_task
+  confirmation:
+    required: true
+  lock: false
+  description: Cancels a currently running cleaning task
+---
+
+### Navigation tasks
+
 # Send the robot to a named waypoint
 # This could be a dock, in which case the robot will automatically dock
 apiVersion: v0.1
@@ -106,7 +172,7 @@ metadata:
     scope: tag/<account_id>/<tag_id>
 spec:
   label: Dock
-  group: Gausium actions
+  group: Navigation tasks
   type: RunScript
   arguments:
     - name: filename
@@ -118,6 +184,7 @@ spec:
   confirmation:
     required: true
   lock: false
+  description: Sends the robot to the charging dock
 ---
 # Send the robot to a named waypoint controlling all available arguments
 apiVersion: v0.1
@@ -127,7 +194,7 @@ metadata:
     scope: tag/<account_id>/<tag_id>
 spec:
   label: Send to named waypoint
-  group: Gausium actions
+  group: Navigation tasks
   type: RunScript
   arguments:
     - name: filename
@@ -142,3 +209,61 @@ spec:
   confirmation:
     required: true
   lock: false
+  description: Sends the robot to a named waypoint
+---
+# Pause the current navigation task
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: pause-navigation
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Pause Navigation Task
+  group: Navigation tasks
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: pause_navigation_task
+  confirmation:
+    required: true
+  lock: false
+  description: Pauses a currently running navigation task
+---
+# Resume a paused navigation task
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: resume-navigation
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Resume Navigation Task
+  group: Navigation tasks
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: resume_navigation_task
+  confirmation:
+    required: true
+  lock: false
+  description: Resumes a previously paused navigation task
+---
+# Cancel the current navigation task
+apiVersion: v0.1
+kind: ActionDefinition
+metadata:
+    id: cancel-navigation
+    scope: tag/<account_id>/<tag_id>
+spec:
+  label: Cancel Navigation Task
+  group: Navigation tasks
+  type: RunScript
+  arguments:
+    - name: filename
+      type: string
+      value: cancel_navigation_task
+  confirmation:
+    required: true
+  lock: false
+  description: Cancels a currently running navigation task

--- a/gausium_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_connector/inorbit_gausium_connector/src/connector.py
@@ -275,6 +275,9 @@ class GausiumConnector(Connector):
             orientation = math.degrees(float(pose["theta"]))
             self.robot_api.send_waypoint(x, y, orientation)
 
+            # Return '0' for success
+            return options["result_function"]("0")
+
         # Pose initalization
         elif command_name == COMMAND_INITIAL_POSE:
             # Localize the robot within the current map
@@ -288,6 +291,9 @@ class GausiumConnector(Connector):
             new_orientation = math.degrees(new_orientation)
             self.robot_api.localize_at(new_x, new_y, new_orientation)
 
+            # Return '0' for success
+            return options["result_function"]("0")
+
         # InOrbit messages (PublishToTopic actions)
         elif command_name == COMMAND_MESSAGE:
             message = args[0]
@@ -297,6 +303,9 @@ class GausiumConnector(Connector):
                 self.robot_api.resume()
             else:
                 return options["result_function"]("1", f"Message '{message}' is not implemented")
+
+            # Return '0' for success
+            return options["result_function"]("0")
 
         else:
             return options["result_function"]("1", f"'{command_name}' is not implemented")

--- a/gausium_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_connector/inorbit_gausium_connector/src/connector.py
@@ -29,7 +29,14 @@ class CustomScripts(Enum):
     """Supported InOrbit CustomScript actions"""
 
     START_CLEANING_TASK = "start_cleaning_task"
+    PAUSE_CLEANING_TASK = "pause_cleaning_task"
+    RESUME_CLEANING_TASK = "resume_cleaning_task"
+    CANCEL_CLEANING_TASK = "cancel_cleaning_task"
+
     SEND_TO_NAMED_WAYPOINT = "send_to_named_waypoint"
+    PAUSE_NAVIGATION_TASK = "pause_navigation_task"
+    RESUME_NAVIGATION_TASK = "resume_navigation_task"
+    CANCEL_NAVIGATION_TASK = "cancel_navigation_task"
 
 
 class CommandMessages(Enum):
@@ -232,12 +239,26 @@ class GausiumConnector(Connector):
                 # Name of the task
                 task_name = script_args.get("task_name", "InOrbit cleaning task action")
                 self.robot_api.start_cleaning_task(map_name, path_name, task_name, loop, loop_count)
+            elif script_name == CustomScripts.PAUSE_CLEANING_TASK.value:
+                self.robot_api.pause_cleaning_task()
+            elif script_name == CustomScripts.RESUME_CLEANING_TASK.value:
+                self.robot_api.resume_cleaning_task()
+            elif script_name == CustomScripts.CANCEL_CLEANING_TASK.value:
+                self.robot_api.cancel_cleaning_task()
+
             elif script_name == CustomScripts.SEND_TO_NAMED_WAYPOINT.value:
                 # The most important argument
                 position_name = script_args.get("position_name")
                 # Defaults to the current map
                 map_name = script_args.get("map_name")
                 self.robot_api.send_to_named_waypoint(position_name, map_name)
+            elif script_name == CustomScripts.PAUSE_NAVIGATION_TASK.value:
+                self.robot_api.pause_navigation_task()
+            elif script_name == CustomScripts.RESUME_NAVIGATION_TASK.value:
+                self.robot_api.resume_navigation_task()
+            elif script_name == CustomScripts.CANCEL_NAVIGATION_TASK.value:
+                self.robot_api.cancel_navigation_task()
+
             else:
                 return options["result_function"](
                     "1", f"Custom command '{script_name}' is not implemented"

--- a/gausium_connector/inorbit_gausium_connector/src/robot/robot_api.py
+++ b/gausium_connector/inorbit_gausium_connector/src/robot/robot_api.py
@@ -181,8 +181,38 @@ class GausiumRobotAPI(ABC):
         pass
 
     @abstractmethod
+    def pause_cleaning_task(self) -> bool:
+        """Pauses the cleaning task"""
+        pass
+
+    @abstractmethod
+    def resume_cleaning_task(self) -> bool:
+        """Resumes the cleaning task"""
+        pass
+
+    @abstractmethod
+    def cancel_cleaning_task(self) -> bool:
+        """Cancels the cleaning task"""
+        pass
+
+    @abstractmethod
     def send_to_named_waypoint(self, **kwargs) -> bool:
         """Sends the robot to a named waypoint"""
+        pass
+
+    @abstractmethod
+    def pause_navigation_task(self) -> bool:
+        """Pauses the navigation task"""
+        pass
+
+    @abstractmethod
+    def resume_navigation_task(self) -> bool:
+        """Resumes the navigation task"""
+        pass
+
+    @abstractmethod
+    def cancel_navigation_task(self) -> bool:
+        """Cancels the navigation task"""
         pass
 
 
@@ -409,6 +439,21 @@ class GausiumCloudAPI(GausiumRobotAPI):
         return self._start_cleaning_task(map_name, path_name, task_name, loop, loop_count)
 
     @override
+    def pause_cleaning_task(self) -> bool:
+        """Pauses the cleaning task"""
+        return self._pause_task_queue()
+
+    @override
+    def resume_cleaning_task(self) -> bool:
+        """Resumes the cleaning task"""
+        return self._resume_task_queue()
+
+    @override
+    def cancel_cleaning_task(self) -> bool:
+        """Cancels the cleaning task"""
+        return self._cancel_task_queue()
+
+    @override
     def send_to_named_waypoint(self, position_name: str, map_name: str | None = None) -> bool:
         """Sends the robot to a named waypoint.
 
@@ -422,6 +467,21 @@ class GausiumCloudAPI(GausiumRobotAPI):
         """
         map_name = map_name if map_name else self._get_current_map_or_raise().map_name
         return self._navigate_to_named_waypoint(map_name, position_name)
+
+    @override
+    def pause_navigation_task(self) -> bool:
+        """Pauses the navigation task"""
+        return self._pause_navigation_task()
+
+    @override
+    def resume_navigation_task(self) -> bool:
+        """Resumes the navigation task"""
+        return self._resume_navigation_task()
+
+    @override
+    def cancel_navigation_task(self) -> bool:
+        """Cancels the navigation task"""
+        return self._cancel_navigation_task()
 
     def _get_current_map_or_raise(self) -> MapData:
         """Get the current map or raise an exception if it's not set"""

--- a/gausium_connector/inorbit_gausium_connector/tests/test_connector.py
+++ b/gausium_connector/inorbit_gausium_connector/tests/test_connector.py
@@ -368,6 +368,154 @@ class TestGausiumConnector:
         callback_kwargs["options"]["result_function"].assert_called_with("0")
         connector.robot_api.send_to_named_waypoint.assert_called_once_with("waypoint_1", "test_map")
 
+    def test_command_callback_pause_cleaning_task(self, connector, callback_kwargs):
+        # Set up the robot to be available
+        connector.robot_api._last_call_successful = True
+        connector.status = {"online": True}
+
+        # Configure the custom command for pausing cleaning task
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["pause_cleaning_task", []]
+
+        # Call the handler
+        connector._inorbit_command_handler(**callback_kwargs)
+
+        # Verify the result function was called with success code
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+
+        # Verify the robot API method was called
+        connector.robot_api.pause_cleaning_task.assert_called_once()
+
+    def test_command_callback_resume_cleaning_task(self, connector, callback_kwargs):
+        # Set up the robot to be available
+        connector.robot_api._last_call_successful = True
+        connector.status = {"online": True}
+
+        # Configure the custom command for resuming cleaning task
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["resume_cleaning_task", []]
+
+        # Call the handler
+        connector._inorbit_command_handler(**callback_kwargs)
+
+        # Verify the result function was called with success code
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+
+        # Verify the robot API method was called
+        connector.robot_api.resume_cleaning_task.assert_called_once()
+
+    def test_command_callback_cancel_cleaning_task(self, connector, callback_kwargs):
+        # Set up the robot to be available
+        connector.robot_api._last_call_successful = True
+        connector.status = {"online": True}
+
+        # Configure the custom command for canceling cleaning task
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["cancel_cleaning_task", []]
+
+        # Call the handler
+        connector._inorbit_command_handler(**callback_kwargs)
+
+        # Verify the result function was called with success code
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+
+        # Verify the robot API method was called
+        connector.robot_api.cancel_cleaning_task.assert_called_once()
+
+    def test_command_callback_pause_navigation_task(self, connector, callback_kwargs):
+        # Set up the robot to be available
+        connector.robot_api._last_call_successful = True
+        connector.status = {"online": True}
+
+        # Configure the custom command for pausing navigation task
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["pause_navigation_task", []]
+
+        # Call the handler
+        connector._inorbit_command_handler(**callback_kwargs)
+
+        # Verify the result function was called with success code
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+
+        # Verify the robot API method was called
+        connector.robot_api.pause_navigation_task.assert_called_once()
+
+    def test_command_callback_resume_navigation_task(self, connector, callback_kwargs):
+        # Set up the robot to be available
+        connector.robot_api._last_call_successful = True
+        connector.status = {"online": True}
+
+        # Configure the custom command for resuming navigation task
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["resume_navigation_task", []]
+
+        # Call the handler
+        connector._inorbit_command_handler(**callback_kwargs)
+
+        # Verify the result function was called with success code
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+
+        # Verify the robot API method was called
+        connector.robot_api.resume_navigation_task.assert_called_once()
+
+    def test_command_callback_cancel_navigation_task(self, connector, callback_kwargs):
+        # Set up the robot to be available
+        connector.robot_api._last_call_successful = True
+        connector.status = {"online": True}
+
+        # Configure the custom command for canceling navigation task
+        callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+        callback_kwargs["args"] = ["cancel_navigation_task", []]
+
+        # Call the handler
+        connector._inorbit_command_handler(**callback_kwargs)
+
+        # Verify the result function was called with success code
+        callback_kwargs["options"]["result_function"].assert_called_with("0")
+
+        # Verify the robot API method was called
+        connector.robot_api.cancel_navigation_task.assert_called_once()
+
+    def test_command_callback_robot_unavailable(self, connector, callback_kwargs):
+        # Set up the robot to be unavailable
+        connector.robot_api._last_call_successful = False
+        connector.status = {"online": False}
+
+        # Test each command with an unavailable robot
+        commands = [
+            "pause_cleaning_task",
+            "resume_cleaning_task",
+            "cancel_cleaning_task",
+            "pause_navigation_task",
+            "resume_navigation_task",
+            "cancel_navigation_task",
+        ]
+
+        for command in commands:
+            # Reset the result function mock
+            callback_kwargs["options"]["result_function"].reset_mock()
+            # Reset the robot API method mock
+            method_name = command
+            robot_api_method = getattr(connector.robot_api, method_name)
+            robot_api_method.reset_mock()
+
+            # Configure the custom command
+            callback_kwargs["command_name"] = COMMAND_CUSTOM_COMMAND
+            callback_kwargs["args"] = [command, []]
+
+            # Call the handler
+            connector._inorbit_command_handler(**callback_kwargs)
+
+            # Verify the result function was called with error code
+            callback_kwargs["options"]["result_function"].assert_called_with(
+                "1", "Robot is not available"
+            )
+
+            # Verify the robot API method was NOT called
+            assert (
+                not robot_api_method.called
+            ), f"Robot API method {method_name} was called when robot was unavailable"
+
     def test_execution_loop(self, connector, robot_info, current_position_data, device_status_data):
         # Setup mock return values based on fixtures
         connector.robot_api.pose = {

--- a/gausium_connector/inorbit_gausium_connector/tests/test_robot_api.py
+++ b/gausium_connector/inorbit_gausium_connector/tests/test_robot_api.py
@@ -135,3 +135,228 @@ class TestGausiumCloudAPIUpdate:
         ):
             # This should not raise an exception despite the invalid model type
             api.update()
+
+
+class TestGausiumCloudAPIPauseResume:
+    """Tests for the GausiumCloudAPI pause() and resume() methods."""
+
+    @pytest.fixture
+    def mock_robot_api(self, robot_info):
+        """Create a mock GausiumCloudAPI instance for testing pause/resume."""
+        api = GausiumCloudAPI(
+            base_url=HttpUrl("http://example.com/"),
+            allowed_model_types=[],  # No validation
+            loglevel="DEBUG",
+        )
+
+        # Mock components to prevent actual HTTP requests
+        api.logger = Mock()
+        api.api_session = Mock()
+
+        # Set up mocks for API methods
+        api._pause_task_queue = Mock(return_value=True)
+        api._resume_task_queue = Mock(return_value=True)
+        api._pause_cleaning_task = Mock(return_value=True)
+        api._resume_cleaning_task = Mock(return_value=True)
+        api._pause_navigation_task = Mock(return_value=True)
+        api._resume_navigation_task = Mock(return_value=True)
+        api._is_cleaning_task_finished = Mock(return_value=True)
+
+        return api
+
+    def test_pause_pre_v3_6_6(self, mock_robot_api):
+        """Test that pause() calls _pause_task_queue() for pre v3-6-6 firmware."""
+        # Mock firmware version check to return False (pre v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=False):
+            # Call the pause method
+            result = mock_robot_api.pause()
+
+            # Verify the result and that the right method was called
+            assert result is True
+            mock_robot_api._pause_task_queue.assert_called_once()
+            mock_robot_api._pause_cleaning_task.assert_not_called()
+            mock_robot_api._pause_navigation_task.assert_not_called()
+
+    def test_pause_post_v3_6_6_cleaning_finished(self, mock_robot_api):
+        """Test that pause() calls _pause_cleaning_task() when cleaning is finished."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # Mock cleaning task is finished
+            mock_robot_api._is_cleaning_task_finished.return_value = True
+
+            # Call the pause method
+            result = mock_robot_api.pause()
+
+            # Verify the result and that the right method was called
+            assert result is True
+            assert mock_robot_api._last_pause_command == "cleaning"
+            mock_robot_api._pause_task_queue.assert_not_called()
+            mock_robot_api._pause_cleaning_task.assert_called_once()
+            mock_robot_api._pause_navigation_task.assert_not_called()
+
+    def test_pause_post_v3_6_6_cleaning_running(self, mock_robot_api):
+        """Test that pause() calls _pause_navigation_task() when cleaning is running."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # Mock cleaning task is not finished
+            mock_robot_api._is_cleaning_task_finished.return_value = False
+
+            # Call the pause method
+            result = mock_robot_api.pause()
+
+            # Verify the result and that the right method was called
+            assert result is True
+            assert mock_robot_api._last_pause_command == "navigation"
+            mock_robot_api._pause_task_queue.assert_not_called()
+            mock_robot_api._pause_cleaning_task.assert_not_called()
+            mock_robot_api._pause_navigation_task.assert_called_once()
+
+    def test_resume_pre_v3_6_6(self, mock_robot_api):
+        """Test that resume() calls _resume_task_queue() for pre v3-6-6 firmware."""
+        # Mock firmware version check to return False (pre v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=False):
+            # Call the resume method
+            result = mock_robot_api.resume()
+
+            # Verify the result and that the right method was called
+            assert result is True
+            mock_robot_api._resume_task_queue.assert_called_once()
+            mock_robot_api._resume_cleaning_task.assert_not_called()
+            mock_robot_api._resume_navigation_task.assert_not_called()
+
+    def test_resume_post_v3_6_6_cleaning_paused(self, mock_robot_api):
+        """Test that resume() calls _resume_cleaning_task() after cleaning was paused."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # Set the last pause command
+            mock_robot_api._last_pause_command = "cleaning"
+
+            # Call the resume method
+            result = mock_robot_api.resume()
+
+            # Verify the result and that the right method was called
+            assert result is True
+            assert mock_robot_api._last_pause_command is None
+            mock_robot_api._resume_task_queue.assert_not_called()
+            mock_robot_api._resume_cleaning_task.assert_called_once()
+            mock_robot_api._resume_navigation_task.assert_not_called()
+
+    def test_resume_post_v3_6_6_navigation_paused(self, mock_robot_api):
+        """Test that resume() calls _resume_navigation_task() after navigation was paused."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # Set the last pause command
+            mock_robot_api._last_pause_command = "navigation"
+
+            # Call the resume method
+            result = mock_robot_api.resume()
+
+            # Verify the result and that the right method was called
+            assert result is True
+            assert mock_robot_api._last_pause_command is None
+            mock_robot_api._resume_task_queue.assert_not_called()
+            mock_robot_api._resume_cleaning_task.assert_not_called()
+            mock_robot_api._resume_navigation_task.assert_called_once()
+
+    def test_resume_post_v3_6_6_no_previous_pause(self, mock_robot_api):
+        """Test that resume() raises an exception if no previous pause command was stored."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # No last pause command set
+            mock_robot_api._last_pause_command = None
+
+            # Call the resume method and expect an exception
+            with pytest.raises(Exception) as excinfo:
+                mock_robot_api.resume()
+
+            # Check the error message
+            assert "No previously paused command found" in str(excinfo.value)
+            mock_robot_api._resume_task_queue.assert_not_called()
+            mock_robot_api._resume_cleaning_task.assert_not_called()
+            mock_robot_api._resume_navigation_task.assert_not_called()
+
+    def test_pause_api_failure(self, mock_robot_api):
+        """Test pause() handles API failure when pausing."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # Test when cleaning is finished
+            mock_robot_api._is_cleaning_task_finished.return_value = True
+            mock_robot_api._pause_cleaning_task.return_value = False
+
+            # Call the pause method
+            result = mock_robot_api.pause()
+
+            # Check result is False due to API failure
+            assert result is False
+            mock_robot_api._pause_cleaning_task.assert_called_once()
+
+            # Reset mocks
+            mock_robot_api._pause_cleaning_task.reset_mock()
+            mock_robot_api._pause_navigation_task.reset_mock()
+
+            # Test when cleaning is running
+            mock_robot_api._is_cleaning_task_finished.return_value = False
+            mock_robot_api._pause_navigation_task.return_value = False
+
+            # Call the pause method
+            result = mock_robot_api.pause()
+
+            # Check result is False due to API failure
+            assert result is False
+            mock_robot_api._pause_navigation_task.assert_called_once()
+
+    def test_resume_api_failure(self, mock_robot_api):
+        """Test resume() handles API failure when resuming."""
+        # Mock firmware version check to return True (post v3-6-6)
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            # Test cleaning case
+            mock_robot_api._last_pause_command = "cleaning"
+            mock_robot_api._resume_cleaning_task.return_value = False
+
+            # Call the resume method
+            result = mock_robot_api.resume()
+
+            # Check result is False due to API failure and last_pause_command is reset
+            assert result is False
+            assert mock_robot_api._last_pause_command is None
+            mock_robot_api._resume_cleaning_task.assert_called_once()
+
+            # Reset mocks
+            mock_robot_api._resume_cleaning_task.reset_mock()
+            mock_robot_api._resume_navigation_task.reset_mock()
+
+            # Test navigation case
+            mock_robot_api._last_pause_command = "navigation"
+            mock_robot_api._resume_navigation_task.return_value = False
+
+            # Call the resume method
+            result = mock_robot_api.resume()
+
+            # Check result is False due to API failure and last_pause_command is reset
+            assert result is False
+            assert mock_robot_api._last_pause_command is None
+            mock_robot_api._resume_navigation_task.assert_called_once()
+
+    def test_last_pause_command_tracking(self, mock_robot_api):
+        """Test that _last_pause_command tracking works correctly across multiple calls."""
+        # Start with no pause command
+        assert mock_robot_api._last_pause_command is None
+
+        # First pause when cleaning is finished
+        with patch.object(mock_robot_api, "_is_firmware_post_v3_6_6", return_value=True):
+            mock_robot_api._is_cleaning_task_finished.return_value = True
+            mock_robot_api.pause()
+            assert mock_robot_api._last_pause_command == "cleaning"
+
+            # Resume cleaning
+            mock_robot_api.resume()
+            assert mock_robot_api._last_pause_command is None
+
+            # Now pause when cleaning is running
+            mock_robot_api._is_cleaning_task_finished.return_value = False
+            mock_robot_api.pause()
+            assert mock_robot_api._last_pause_command == "navigation"
+
+            # Resume navigation
+            mock_robot_api.resume()
+            assert mock_robot_api._last_pause_command is None


### PR DESCRIPTION
### 🗒️ Description

Add support for the following CustomCommands:
* `pause_cleaning_task`
* `resume_cleaning_task`
* `cancel_cleaning_task`
* `pause_navigation_task`
* `resume_navigation_task`
* `cancel_navigation_task`

Add support for the following messages:
* `inorbit_pause`
* `inorbit_resume`
