### PR TITLE
Gausium connector: Upgrade `inorbit-connector` version to 1.2.0

### DIFF
--- a/gausium_connector/requirements.txt
+++ b/gausium_connector/requirements.txt
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-inorbit-connector==1.1.3
-inorbit-edge>=1.18.0
+inorbit-connector==1.2.0
 httpx~=0.28
 pytz>=2022.7
 ruamel.yaml>=0.18,<0.19


### PR DESCRIPTION
# Description

Gausium connector: Upgrade `inorbit-connector` version to 1.2.0