### PR TITLE
InOrbit MT only works when edge executor is idle

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -100,7 +100,6 @@ class MirConnector(Connector):
             mir_api=self.mir_api,
             inorbit_sess=self._get_session(),
             robot_tz_info=self.robot_tz_info,
-            enable_io_mission_tracking=True,
         )
 
         # Set up InOrbit Edge Executor for mission execution
@@ -198,14 +197,8 @@ class MirConnector(Connector):
             # 3. Needs an interface for supporting mission related actions
 
             if script_name == "queue_mission" and script_args[0] == "--mission_id":
-                self.mission_tracking.mir_mission_tracking_enabled = (
-                    self._get_session().missions_module.executor.wait_until_idle(0)
-                )
                 await self.mir_api.queue_mission(script_args[1])
             elif script_name == "run_mission_now" and script_args[0] == "--mission_id":
-                self.mission_tracking.mir_mission_tracking_enabled = (
-                    self._get_session().missions_module.executor.wait_until_idle(0)
-                )
                 await self.mir_api.abort_all_missions()
                 await self.mir_api.queue_mission(script_args[1])
             elif script_name == "abort_missions":

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -18,13 +18,8 @@ class MirInorbitMissionTracking:
         mir_api,
         inorbit_sess,
         robot_tz_info,
-        enable_io_mission_tracking=True,
     ):
         self.logger = logging.getLogger(name=self.__class__.__name__)
-        # Hack to allow MiR defined missions and InOrbit missions to co-exist
-        # When an InOrbit mission is running, we disable tracking for MiR defined
-        # missions.
-        self.mir_mission_tracking_enabled = True
         self.executing_mission_id = None
         self.last_reported_mission_id = None
         self.last_reported_mission_progress = 0.0
@@ -67,10 +62,9 @@ class MirInorbitMissionTracking:
         return mission
 
     async def report_mission(self, status, metrics):
-        # Hack to allow MiR defined missions and InOrbit missions to co-exist
-        # When an InOrbit mission is running, we disable tracking for MiR defined
-        # missions.
-        if not self.mir_mission_tracking_enabled:
+        # When the edge mission executor is running an InOrbit-dispatched mission, it owns
+        # mission tracking. Skip robot-side polling to avoid duplicate reports.
+        if not self.inorbit_sess.missions_module.executor.wait_until_idle(0):
             return
         mission = await self.get_current_mission()
         if mission:

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -139,24 +139,11 @@ async def test_command_callback_missions(connector_with_mission_tracking, callba
         callback_kwargs["options"]["result_function"].reset_mock()
         connector.mir_api.reset_mock()
 
-    # Simulate an executor timeout, which should disable robot mission tracking
-    connector._get_session().missions_module.executor.wait_until_idle = Mock(return_value=False)
-    # Initial state is True, will be updated when command is executed
-    assert connector.mission_tracking.mir_mission_tracking_enabled is True
-    callback_kwargs["command_name"] = "customCommand"
-    callback_kwargs["args"] = ["queue_mission", ["--mission_id", "1"]]
-    await connector._inorbit_command_handler(**callback_kwargs)
-    assert connector.mission_tracking.mir_mission_tracking_enabled is False
-    assert connector.mir_api.queue_mission.call_args == call("1")
-    callback_kwargs["options"]["result_function"].assert_called_with(CommandResultCode.SUCCESS)
-    reset_mock()
-
-    # Queue mission
-    connector._get_session().missions_module.executor.wait_until_idle = Mock(return_value=True)
+    # Queue mission — the robot-side tracker self-gates on executor state at report time,
+    # so the command handler just forwards to the MiR API.
     callback_kwargs["command_name"] = "customCommand"
     callback_kwargs["args"] = ["queue_mission", ["--mission_id", "2"]]
     await connector._inorbit_command_handler(**callback_kwargs)
-    assert connector.mission_tracking.mir_mission_tracking_enabled is True
     assert connector.mir_api.queue_mission.call_args == call("2")
     callback_kwargs["options"]["result_function"].assert_called_with(CommandResultCode.SUCCESS)
     reset_mock()

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -47,9 +47,7 @@ async def test_skips_reporting_while_edge_executor_busy(
     mission_tracking.get_current_mission = AsyncMock(return_value=sample_mir_mission_data)
 
     # Executor idle — robot-side tracking should publish.
-    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(
-        return_value=True
-    )
+    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=True)
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 1
     assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 1

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -18,7 +18,6 @@ def mission_tracking():
         mir_api=MagicMock(autospec=MirApiV2),
         inorbit_sess=MagicMock(autospec=RobotSession),
         robot_tz_info=pytz.timezone("UTC"),
-        enable_io_mission_tracking=True,
     )
     mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=True)
     return mission_tracking
@@ -42,28 +41,30 @@ async def test_get_current_mission(mission_tracking):
 
 
 @pytest.mark.asyncio
-async def test_toggle_mir_tracking(
+async def test_skips_reporting_while_edge_executor_busy(
     mission_tracking, sample_metrics_data, sample_status_data, sample_mir_mission_data
 ):
     mission_tracking.get_current_mission = AsyncMock(return_value=sample_mir_mission_data)
 
-    # MiR tracking should be enabled
-    mission_tracking.mir_mission_tracking_enabled = True
+    # Executor idle — robot-side tracking should publish.
+    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=True)
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 1
+    assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 1
     mission_tracking.get_current_mission.reset_mock()
+    mission_tracking.inorbit_sess.publish_key_values.reset_mock()
 
-    # Disable mission tracking. This is usually set by the connector
-    mission_tracking.mir_mission_tracking_enabled = False
+    # Executor busy (running an InOrbit-dispatched mission) — tracker must stay silent.
+    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=False)
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 0
+    assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 0
 
 
 @pytest.mark.asyncio
 async def test_report_mission(
     mission_tracking, sample_metrics_data, sample_status_data, sample_mir_mission_data
 ):
-    mission_tracking.mir_mission_tracking_enabled = True
     mission_tracking.get_current_mission = AsyncMock(return_value=sample_mir_mission_data)
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     reported_mission = mission_tracking.inorbit_sess.publish_key_values.call_args.kwargs[
@@ -96,26 +97,6 @@ async def test_report_mission(
     assert DeepDiff(reported_mission, should_be) == {}
 
 
-@pytest.mark.asyncio
-async def test_toggle_inorbit_tracking(
-    mission_tracking, sample_metrics_data, sample_status_data, sample_mir_mission_data
-):
-    # Enable MiR tracking. This is ussually set by the connector
-    mission_tracking.mir_mission_tracking_enabled = True
-    mission_tracking.get_current_mission = AsyncMock(return_value=sample_mir_mission_data)
-
-    # Should be enabled
-    await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
-    assert len(mission_tracking.get_current_mission.call_args_list) == 1
-    assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 1
-
-    # Disable InOrbit Mission Tracking
-    mission_tracking.enable_io_mission_tracking = False
-    await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
-    assert len(mission_tracking.get_current_mission.call_args_list) == 2
-    assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 1
-
-
 class TestSafeLocalizeTimestamp:
     """Test suite for the _safe_localize_timestamp function."""
 
@@ -126,7 +107,6 @@ class TestSafeLocalizeTimestamp:
             mir_api=MagicMock(autospec=MirApiV2),
             inorbit_sess=MagicMock(autospec=RobotSession),
             robot_tz_info=pytz.timezone("America/Los_Angeles"),
-            enable_io_mission_tracking=True,
         )
 
     def test_timestamp_without_timezone_info(self, pst_mission_tracking):
@@ -173,7 +153,6 @@ class TestSafeLocalizeTimestamp:
             mir_api=MagicMock(autospec=MirApiV2),
             inorbit_sess=MagicMock(autospec=RobotSession),
             robot_tz_info=pytz.timezone("UTC"),
-            enable_io_mission_tracking=True,
         )
 
         # Timestamp without timezone should get UTC applied

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -47,7 +47,9 @@ async def test_skips_reporting_while_edge_executor_busy(
     mission_tracking.get_current_mission = AsyncMock(return_value=sample_mir_mission_data)
 
     # Executor idle — robot-side tracking should publish.
-    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=True)
+    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(
+        return_value=True
+    )
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 1
     assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 1
@@ -55,7 +57,9 @@ async def test_skips_reporting_while_edge_executor_busy(
     mission_tracking.inorbit_sess.publish_key_values.reset_mock()
 
     # Executor busy (running an InOrbit-dispatched mission) — tracker must stay silent.
-    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=False)
+    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(
+        return_value=False
+    )
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 0
     assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 0


### PR DESCRIPTION
## Fix duplicate mission tracking in MiR connector

### Background

The MiR connector reports mission state to InOrbit through two independent paths:

1. **Robot-side poller** (`mission_tracking.py`) — polls the MiR API every execution loop and publishes `mission_tracking` key-values over MQTT. This is how missions *dispatched directly from the  robot* (e.g. from the MiR UI or Fleet) show up in InOrbit automatically.
2. **Edge mission executor** (`mission_exec.py`, backed by `inorbit-edge-executor`) — runs missions *dispatched from InOrbit* via the `executeMissionAction` custom command and reports their lifecycle through the executor SDK.

Both paths are valid and intentional: each covers a different dispatch origin.

### The bug

Customers reported that missions were appearing twice in InOrbit. When InOrbit dispatches a mission via the edge executor, the executor queues it on the MiR. The robot-side poller then observes the same mission on the MiR API and publishes its own tracking stream in parallel — so the backend sees two sets of updates for the same physical mission and creates two mission records.

### Root cause

There was already a gate to prevent this: a `mir_mission_tracking_enabled` flag on the poller that was supposed to be disabled while an InOrbit-initiated mission was running. However, the gate was only wired into the *legacy* custom commands (`queue_mission` / `run_mission_now`) and was never applied on the newer `executeMissionAction` path that the edge executor uses today. The flag also relied on the command handler remembering to toggle it, which is fragile — if the executor started or finished a mission by any other route, the flag would drift out of sync.

A secondary finding: the constructor accepted an `enable_io_mission_tracking` argument that was never stored on the instance, so a test that tried to use it was silently asserting nothing.

### The fix

Replace the externally-managed flag with a single runtime check inside the poller itself: before publishing, ask the edge executor whether it is idle. If the executor is running any mission — regardless of how it was dispatched — the robot-side poller stays silent and lets the executor own the tracking stream. When the executor is idle, the poller works exactly as before and continues to auto-track robot-initiated missions.

This collapses both dispatch paths under one consistent rule, removes the stale flag and its dead constructor argument, and simplifies the command handlers. Existing tests were updated to drive the gate through the executor mock, and the no-op test was replaced with one that actually verifies the new behavior.