### PR TITLE
Bump mir_connector version: 1.2.0 → 1.2.1

### DIFF
--- a/mir_connector/.bumpversion.toml
+++ b/mir_connector/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.2.0"
+current_version = "1.2.1"
 commit = true
 message = "Bump mir_connector version: {current_version} → {new_version}"
 tag = true

--- a/mir_connector/inorbit_mir_connector/__init__.py
+++ b/mir_connector/inorbit_mir_connector/__init__.py
@@ -6,7 +6,7 @@ __author__ = "InOrbit"
 __email__ = "support@inorbit.ai"
 # Do not edit this string manually, always use bump-my-version
 # See https://github.com/inorbit-ai/inorbit-robot-connectors/tree/main/mir_connector#version-bump
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def get_module_version():

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -82,5 +82,5 @@ setup(
     python_requires=">=3.10",
     # Do not edit this string manually, always use bump-my-version. See
     # https://github.com/inorbit-ai/inorbit-robot-connectors/tree/main/mir_connector#version-bump
-    version="1.2.0",
+    version="1.2.1",
 )


### PR DESCRIPTION
Patch bump to re-trigger the publish workflow that didn't fire after #91 was merged.

## Why

[PR #91](https://github.com/inorbit-ai/inorbit-robot-connectors/pull/91) bumped `setup.py` / `.bumpversion.toml` / `__init__.py` to `1.2.0` inside the feature branch. The squash-merge commit's message was *"Upgrade MiR connector to inorbit-connector 2.3 and add OTEL metrics (#91)"*, which doesn't match the publish-job gate:

```yaml
if: contains(github.event.head_commit.message, 'Bump mir_connector version')
```

Result: neither `publish-pypi` nor `publish-docker` ran. `inorbit-mir-connector 1.2.0` was never published to TestPyPI or to GAR (latest there is still `1.1.0`).

## What this PR does

- `1.2.0 → 1.2.1` across `setup.py`, `.bumpversion.toml`, `inorbit_mir_connector/__init__.py` (via `bump-my-version bump patch`)
- Signed annotated tag `mir_connector-v1.2.1` already pushed to origin
- No other code changes — `1.2.1` ships PR #91's payload (inorbit-connector 2.3 + OTEL metrics)

## How to land

**Squash-merge with the PR title as the commit message.** That puts `"Bump mir_connector version: 1.2.0 → 1.2.1"` on `main`, satisfying the workflow gate and triggering `publish-pypi` (TestPyPI) and `publish-docker` (GAR).
