### PR TITLE
Remove stale bumpversion config from omron connector

### DIFF
--- a/omron_flowcore_connector/pyproject.toml
+++ b/omron_flowcore_connector/pyproject.toml
@@ -59,14 +59,6 @@ inorbit-omron-connector = "inorbit_omron_connector.main:start"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.bumpversion]
-current_version = "0.2.1"
-commit = true
-tag = true
-message = "Bump inorbit-omron-connector version: {current_version} → {new_version}"
-tag_name = "inorbit-omron-connector-v{new_version}"
-tag_message = "Bump inorbit-omron-connector version: {current_version} → {new_version}"
-
 [tool.hatch.build.targets.wheel]
 packages = ["inorbit_omron_connector"]
 


### PR DESCRIPTION
### 🗒️ Description

Removes the stale `[tool.bumpversion]` section from `omron_flowcore_connector/pyproject.toml`. The omron connector uses `make bump` (uv-based), not bump-my-version. The leftover config had `current_version = "0.2.1"` which was wrong (actual version is 0.2.5), and could cause confusion.

Also deleted the bare `v0.2.5` tag from the remote (likely created by mistakenly using `bumpversion` instead of the make script) — it lacked the `inorbit-omron-connector-` prefix.