### PR TITLE
Bump MiR inorbit-connector package

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -103,11 +103,14 @@ class MirConnector(Connector):
             robot_tz_info=self.robot_tz_info,
         )
 
-        # Set up InOrbit Edge Executor for mission execution
+        # Set up InOrbit Edge Executor for mission execution.
+        # `inorbit_rest_api_endpoint` is a typed `HttpUrl`; cast to str
+        # because `MissionInOrbitAPI` concatenates the URL with str paths
+        # and assumes a plain string.
         self.mission_executor: MirMissionExecutor = MirMissionExecutor(
             robot_id=robot_id,
             inorbit_api=MissionInOrbitAPI(
-                base_url=self._get_session().inorbit_rest_api_endpoint,
+                base_url=str(self._get_session().inorbit_rest_api_endpoint),
                 api_key=self.config.api_key,
             ),
             mir_api=self.mir_api,

--- a/mir_connector/inorbit_mir_connector/tests/test_metrics_endpoint.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_metrics_endpoint.py
@@ -6,10 +6,10 @@
 
 Builds a real :class:`MirConnector` with ``metrics.enabled=True``, starts the
 metrics HTTP server, exercises both a framework counter and a domain counter,
-then scrapes ``/metrics`` and asserts both metric families appear. This
-validates that the inorbit-connector 2.3 upgrade correctly hooks into our
-domain instruments (declared in ``inorbit_mir_connector.src.metrics``) via
-the shared global MeterProvider.
+then scrapes ``/metrics`` and asserts both metric families appear. Validates
+that this connector correctly hooks into the framework's shared global
+MeterProvider for its domain instruments (declared in
+``inorbit_mir_connector.src.metrics``).
 
 OTEL's MeterProvider is a process-global singleton, so this test deliberately
 runs as a single non-parametrized case.
@@ -107,14 +107,14 @@ def test_metrics_endpoint_serves_framework_and_domain_metrics(metrics_connector)
 
     # Framework gauges are registered eagerly in Connector.__init__ via
     # register_framework_gauges, so they appear on every scrape regardless
-    # of whether the run loop has started. Note: the Prometheus exporter
-    # prefixes every metric with the exporter namespace ("inorbit_connector"),
-    # which means the framework instrument "inorbit.connector.up" becomes
-    # "inorbit_connector_inorbit_connector_up" in the output.
-    assert "inorbit_connector_up" in body
-    assert "inorbit_connector_session_connected" in body
+    # of whether the run loop has started. With inorbit-connector >= 2.5
+    # the exporter namespace is derived per connector_type as
+    # `inorbit_<connector_type>_connector`, so the framework instruments
+    # surface as `inorbit_MiR100_connector_*` for this fixture.
+    assert "inorbit_MiR100_connector_up" in body
+    assert "inorbit_MiR100_connector_session_connected" in body
 
-    # Domain instruments are exported via the same global MeterProvider, so
-    # they pick up the same namespace prefix.
-    assert "mir_api_requests_total" in body
-    assert "mir_api_request_duration_seconds" in body
+    # Domain instruments share the same global MeterProvider, so they pick
+    # up the same per-connector_type namespace prefix.
+    assert "inorbit_MiR100_connector_mir_api_requests_total" in body
+    assert "inorbit_MiR100_connector_mir_api_request_duration_seconds" in body

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -24,7 +24,7 @@ requirements = [
     # InOrbit. The ``[video]`` extra on inorbit-connector pulls
     # ``inorbit-edge[video]>=2.1,<3`` transitively, so we don't declare
     # inorbit-edge separately.
-    "inorbit-connector[video]~=2.3.0",
+    "inorbit-connector[video]~=2.5.0",
     "inorbit-edge-executor~=3.2.5",
 ]
 


### PR DESCRIPTION
## Summary

- Bump `inorbit-connector[video]` to `~=2.5.0`.
- Cast `session.inorbit_rest_api_endpoint` to `str` when constructing `MissionInOrbitAPI`. Framework 2.5 types the field as `HttpUrl`; `inorbit-edge-executor` still concatenates it with str (`"InOrbit API: " + base_url`) and raises `TypeError`.
- Update `tests/test_metrics_endpoint.py` to assert the new per-`connector_type` wire names (`inorbit_MiR100_connector_*`).

## Compatibility

Framework 2.5 derives the Prometheus exporter namespace per `connector_type` (`inorbit_<connector_type>_connector`), so wire-level metric names change from `inorbit_connector_*` to `inorbit_<connector_type>_connector_*`. Dashboards/alerts need a one-time rename or a `inorbit_*_connector_*` wildcard. To preserve the old name, set `MetricsConfig.exporter_namespace="inorbit_connector"` explicitly.

## Test plan

- [x] `pytest inorbit_mir_connector/tests/` — 90 passed against `inorbit-connector==2.5.0`.
- [ ] Deploy to a staging site; confirm GCP descriptors appear under `workload.googleapis.com/inorbit_<MiR_model>_connector_*` with the expected `metricKind`.