### PR TITLE
Add inorbit-connector-developer skill as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "template-connector"]
+	path = template-connector
+	url = https://github.com/inorbit-ai/template-connector.git


### PR DESCRIPTION
Vendors [inorbit-ai/template-connector](https://github.com/inorbit-ai/template-connector) as a git submodule at `template-connector/`, making its `inorbit-connector-developer` skill (under `.claude/skills/`) available in this repo for connector development guidance.

Adds only `.gitmodules` and the submodule gitlink — no changes to any connector.

Clone with submodules: `git clone --recurse-submodules`, or `git submodule update --init` in an existing checkout.