### PR TITLE
Bump mir_connector version: 1.3.0 → 2.0.0

### DIFF
--- a/mir_connector/.bumpversion.toml
+++ b/mir_connector/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.3.0"
+current_version = "2.0.0"
 commit = true
 message = "Bump mir_connector version: {current_version} → {new_version}"
 tag = true

--- a/mir_connector/inorbit_mir_connector/__init__.py
+++ b/mir_connector/inorbit_mir_connector/__init__.py
@@ -6,7 +6,7 @@ __author__ = "InOrbit"
 __email__ = "support@inorbit.ai"
 # Do not edit this string manually, always use bump-my-version
 # See https://github.com/inorbit-ai/inorbit-robot-connectors/tree/main/mir_connector#version-bump
-__version__ = "1.3.0"
+__version__ = "2.0.0"
 
 
 def get_module_version():

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -83,5 +83,5 @@ setup(
     python_requires=">=3.10",
     # Do not edit this string manually, always use bump-my-version. See
     # https://github.com/inorbit-ai/inorbit-robot-connectors/tree/main/mir_connector#version-bump
-    version="1.3.0",
+    version="2.0.0",
 )


### PR DESCRIPTION
Major version bump to 2.0.0 to release the inorbit-connector v3 migration (#97), which is a breaking change for existing configurations:

- Flat config schema (`connector_config` + `fleet:` list) replacing the `common:`/inheritance format; `${VAR}` expansion removed.
- Per-robot connection moved to `MirRobotConfig` fleet entries; shared credentials/API version under `connector_config`, injected via `INORBIT_MIR_*` env vars.
- Metrics reworked onto the framework's canonical `upstream.http.*` family.

Updates `setup.py`, `inorbit_mir_connector/__init__.py`, and `.bumpversion.toml`. No release tag is pushed from this branch; tag `mir_connector-v2.0.0` should be created on the merged commit.