### PR TITLE
Move connector-dev skill submodule under .claude

### DIFF
--- a/.claude/skills/inorbit-connector-developer
+++ b/.claude/skills/inorbit-connector-developer
@@ -1,0 +1,1 @@
+../vendor/template-connector/.claude/skills/inorbit-connector-developer

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "template-connector"]
-	path = template-connector
+	path = .claude/vendor/template-connector
 	url = https://github.com/inorbit-ai/template-connector.git


### PR DESCRIPTION
Follow-up to #98. Relocates the `template-connector` submodule from the repo root to `.claude/vendor/template-connector`, and symlinks `.claude/skills/inorbit-connector-developer` → its skill directory.

This puts the `inorbit-connector-developer` skill at the conventional `.claude/skills/<name>/` path (so it's discovered there) and removes the vendored repo from the repo root, while keeping it a submodule that stays updatable from upstream (`git submodule update --remote`).

A submodule clones the whole `template-connector` repo, and the skill is a subfolder of it — so it can't be placed at `.claude/skills/<name>/` directly; the symlink bridges that.

Clone with `--recurse-submodules` (or run `git submodule update --init`).