### PR TITLE
MiR Connector: Prevent battery percentage value from being overwritten by battery capacity [mAh] value

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -443,17 +443,19 @@ class MirConnector(Connector):
             remaining_pct = None
             remaining_sec = None
             for k, v in batt_vals.items():
-                if "Remaining battery capacity" in k:
+                if k == "Remaining battery capacity [%]":
                     remaining_pct = float(v)
                 elif "Remaining battery time [sec]" in k:
                     remaining_sec = float(v)
+                if remaining_pct is not None and remaining_sec is not None:
+                    break
             # Fallback to status if diagnostics doesn't have battery data (e.g., v2 firmware)
             if remaining_pct is None and self.status.get("battery_percentage") is not None:
                 remaining_pct = float(self.status.get("battery_percentage"))
             if remaining_sec is None and self.status.get("battery_time_remaining") is not None:
                 remaining_sec = float(self.status.get("battery_time_remaining"))
             if remaining_pct is not None:
-                key_values["battery percent"] = to_inorbit_percent(remaining_pct)
+                key_values["battery percent"] = to_inorbit_percent(remaining_pct, "battery percent")
             if remaining_sec is not None:
                 key_values["battery_time_remaining"] = int(remaining_sec)
 
@@ -465,7 +467,9 @@ class MirConnector(Connector):
                     avg_cpu = float(v)
                     break
             if avg_cpu is not None:
-                system_stats["cpu_load_percentage"] = to_inorbit_percent(avg_cpu)
+                system_stats["cpu_load_percentage"] = to_inorbit_percent(
+                    avg_cpu, "cpu_load_percentage"
+                )
 
             # CPU temperature from diagnostics
             cpu_temp_vals = (diagnostics.get(CPU_TEMP_PATH, {}) or {}).get("values", {})
@@ -481,12 +485,16 @@ class MirConnector(Connector):
             memory_vals = (diagnostics.get(MEMORY_PATH, {}) or {}).get("values", {})
             memory_usage_pct = calculate_usage_percent(memory_vals, "memory_usage_percent")
             if memory_usage_pct is not None:
-                system_stats["ram_usage_percentage"] = to_inorbit_percent(memory_usage_pct)
+                system_stats["ram_usage_percentage"] = to_inorbit_percent(
+                    memory_usage_pct, "ram_usage_percentage"
+                )
 
             disk_vals = (diagnostics.get(HARDDRIVE_PATH, {}) or {}).get("values", {})
             disk_usage_pct = calculate_usage_percent(disk_vals, "disk_usage_percent")
             if disk_usage_pct is not None:
-                system_stats["hdd_usage_percentage"] = to_inorbit_percent(disk_usage_pct)
+                system_stats["hdd_usage_percentage"] = to_inorbit_percent(
+                    disk_usage_pct, "hdd_usage_percentage"
+                )
 
             # WiFi details from diagnostics
             wifi_vals = (diagnostics.get(WIFI_PATH, {}) or {}).get("values", {})

--- a/mir_connector/inorbit_mir_connector/src/utils.py
+++ b/mir_connector/inorbit_mir_connector/src/utils.py
@@ -4,20 +4,38 @@
 
 """Utility functions for MiR connector data processing."""
 
+import logging
 import re
 from typing import Optional
 
+logger = logging.getLogger(__name__)
 
-def to_inorbit_percent(value: float) -> float:
-    """Convert percentage (0-100) to InOrbit format (0-1).
+
+def to_inorbit_percent(value: float, label: str = "") -> float:
+    """Scale a 0-100 percentage to InOrbit's 0-1 fraction.
+
+    Does NOT clamp. An out-of-range input is logged at WARNING and passed
+    through (scaled), so a bad value surfaces in the UI instead of being
+    silently masked. A previous silent clamp hid a unit bug where an absolute
+    battery capacity (mAh) was matched as the percentage and pinned to 100%.
 
     Args:
-        value: Percentage value between 0-100
+        value: Percentage value, normally between 0-100
+        label: Optional name of the metric being converted, included in the
+            out-of-range warning so it is traceable to its source.
 
     Returns:
-        Normalized value between 0-1
+        The value scaled by 1/100 (not clamped)
     """
-    return max(0.0, min(100.0, value)) / 100.0
+    if not 0.0 <= value <= 100.0:
+        target = f" for '{label}'" if label else ""
+        logger.warning(
+            "Percentage value %s%s is outside the expected 0-100 range; "
+            "publishing scaled value anyway",
+            value,
+            target,
+        )
+    return value / 100.0
 
 
 def parse_number(value: object) -> Optional[float]:

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -418,6 +418,7 @@ async def test_connector_loop(connector_with_mission_tracking, monkeypatch):
             "values": {
                 "Remaining battery capacity [%]": 93.5,
                 "Remaining battery time [sec]": 89725,
+                "Remaining battery capacity [mAh]": 23194,
             }
         },
         "/Computer/Network/Wifi": {

--- a/mir_connector/inorbit_mir_connector/tests/test_utils.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_utils.py
@@ -21,10 +21,16 @@ class TestToInorbitPercent:
         assert to_inorbit_percent(100.0) == 1.0
         assert to_inorbit_percent(0.0) == 0.0
 
-    def test_out_of_range_values(self):
-        """Test values outside 0-100 range are clamped."""
-        assert to_inorbit_percent(-10.0) == 0.0
-        assert to_inorbit_percent(150.0) == 1.0
+    def test_out_of_range_values(self, caplog):
+        """Out-of-range values are scaled (not clamped) and logged at WARNING."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            assert to_inorbit_percent(-10.0) == -0.1
+            assert to_inorbit_percent(150.0) == 1.5
+            assert to_inorbit_percent(23194.0, "battery percent") == 231.94
+        assert "outside the expected 0-100 range" in caplog.text
+        assert "battery percent" in caplog.text
 
     def test_decimal_values(self):
         """Test decimal percentage values."""


### PR DESCRIPTION
### 🗒️ Description

**Bug:** InOrbit showed MiR battery percent stuck at **100%** regardless of the robot's real charge (constantly publishing `1.0`).

**Root cause (confirmed live):** the MiR `/experimental/diagnostics` → `/Power System/Battery` node contains **two** keys that both contain the substring `Remaining battery capacity`:

```
"Remaining battery capacity [%]":   "86.59"   ← the real percentage
"Remaining battery capacity [mAh]": "23194"   ← absolute capacity, ordered last
```

The battery loop matched the loose substring `"Remaining battery capacity"` with **no `break`**, so the `[mAh]` sibling (last in iteration order) overwrote the percentage. `to_inorbit_percent` then **silently clamped** that `>=100` value to `1.0`, so the UI showed 100% no matter the real charge. Verified on a robot reporting **86.59%** across `status`, `metrics`, and diagnostics `[%]` — yet the connector published `1.0`.

The status fallback (`battery_percentage`) never fired because `remaining_pct` had already been set by the mAh match.

**Changes (minimal footprint):**
- `connector.py` — match `"Remaining battery capacity [%]"` **exactly** and `break` once percent + time are found, so the `[mAh]` key can never win.
- `utils.py` — `to_inorbit_percent` **no longer clamps**. It still scales by `1/100` (scaling is fine), but now logs a **WARNING** when the input is outside `0-100` and publishes the scaled value anyway. Letting an out-of-range value show in the UI is exactly what would have surfaced this bug sooner, instead of it being silently masked as a clean 100%.
- tests — add the `[mAh]` sibling key (ordered last) to the battery fixture so the regression is reproduced; update the util out-of-range test for the no-clamp behavior.

