### PR TITLE
fix(mir): prevent duplicate mission tracking via edge executor

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -148,6 +148,7 @@ class MirConnector(Connector):
                 mir_api=self.mir_api,
                 inorbit_sess=self._get_session(),
                 robot_tz_info=self.robot_tz_info,
+                mission_executor=self.mission_executor,
             )
         return self._mission_tracking
 
@@ -398,14 +399,14 @@ class MirConnector(Connector):
         )
 
         # publish key values
-        if self._get_session().missions_module.executor.wait_until_idle(0):
-            mode_text = self.status.get("mode_text")
-            state_text = self.status.get("state_text")
-            mission_text = self.status.get("mission_text")
-        else:
+        if await self.mission_executor.has_active_mission():
             mode_text = "Mission"
             state_text = "Executing"
             mission_text = "Mission"
+        else:
+            mode_text = self.status.get("mode_text")
+            state_text = self.status.get("state_text")
+            mission_text = self.status.get("mission_text")
 
         # TODO(Elvio): Move key values to a "values.py" and represent them with constants
         key_values = {

--- a/mir_connector/inorbit_mir_connector/src/mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_exec.py
@@ -126,6 +126,25 @@ class MirMissionExecutor:
         """Check if the mission executor is initialized."""
         return self._initialized
 
+    async def has_active_mission(self) -> bool:
+        """True if an InOrbit-dispatched mission is currently executing for this robot.
+
+        Used by robot-side mission tracking to avoid double-reporting a mission the edge
+        executor already owns. Backed by the executor's persisted busy-check (the same
+        query ``submit_work`` uses to reject new work for a busy robot), so it stays
+        accurate after a mission finishes even though completed workers linger in the
+        in-memory pool. Returns False before initialization (no executor, so no
+        dispatched mission can be running).
+        """
+        if not self._initialized or not self._worker_pool:
+            return False
+        # TODO: this busy-check belongs on WorkerPool itself (it owns the DB). Once
+        # inorbit-edge-executor exposes a public `WorkerPool.has_active_mission(robot_id)`,
+        # replace the private `_db` access below with
+        # `return await self._worker_pool.has_active_mission(self.robot_id)`.
+        active = await self._worker_pool._db.fetch_robot_active_mission(self.robot_id)
+        return active is not None
+
     async def handle_command(self, script_name: str, script_args: dict, options: dict) -> bool:
         """
         Handle mission-related custom commands.

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -18,6 +18,7 @@ class MirInorbitMissionTracking:
         mir_api,
         inorbit_sess,
         robot_tz_info,
+        mission_executor,
     ):
         self.logger = logging.getLogger(name=self.__class__.__name__)
         self.executing_mission_id = None
@@ -27,6 +28,7 @@ class MirInorbitMissionTracking:
         self.mir_api = mir_api
         self.inorbit_sess = inorbit_sess
         self.robot_tz_info = robot_tz_info
+        self.mission_executor = mission_executor
 
     def _safe_localize_timestamp(self, timestamp_str: str) -> float:
         """Convert ISO timestamp string to Unix timestamp, handling timezone conversion.
@@ -64,7 +66,7 @@ class MirInorbitMissionTracking:
     async def report_mission(self, status, metrics):
         # When the edge mission executor is running an InOrbit-dispatched mission, it owns
         # mission tracking. Skip robot-side polling to avoid duplicate reports.
-        if not self.inorbit_sess.missions_module.executor.wait_until_idle(0):
+        if await self.mission_executor.has_active_mission():
             return
         mission = await self.get_current_mission()
         if mission:

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -5,7 +5,7 @@
 import pytest
 import pytz
 from datetime import datetime
-from unittest.mock import MagicMock, Mock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock
 from inorbit_edge.robot import RobotSession
 from inorbit_mir_connector.src.mir_api import MirApiV2
 from inorbit_mir_connector.src.mission_tracking import MirInorbitMissionTracking
@@ -18,8 +18,10 @@ def mission_tracking():
         mir_api=MagicMock(autospec=MirApiV2),
         inorbit_sess=MagicMock(autospec=RobotSession),
         robot_tz_info=pytz.timezone("UTC"),
+        mission_executor=MagicMock(),
     )
-    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=True)
+    # No InOrbit-dispatched mission active by default.
+    mission_tracking.mission_executor.has_active_mission = AsyncMock(return_value=False)
     return mission_tracking
 
 
@@ -46,18 +48,16 @@ async def test_skips_reporting_while_edge_executor_busy(
 ):
     mission_tracking.get_current_mission = AsyncMock(return_value=sample_mir_mission_data)
 
-    # Executor idle — robot-side tracking should publish.
-    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(return_value=True)
+    # No InOrbit-dispatched mission active — robot-side tracking should publish.
+    mission_tracking.mission_executor.has_active_mission = AsyncMock(return_value=False)
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 1
     assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 1
     mission_tracking.get_current_mission.reset_mock()
     mission_tracking.inorbit_sess.publish_key_values.reset_mock()
 
-    # Executor busy (running an InOrbit-dispatched mission) — tracker must stay silent.
-    mission_tracking.inorbit_sess.missions_module.executor.wait_until_idle = Mock(
-        return_value=False
-    )
+    # An InOrbit-dispatched mission is running in the edge executor — tracker must stay silent.
+    mission_tracking.mission_executor.has_active_mission = AsyncMock(return_value=True)
     await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
     assert len(mission_tracking.get_current_mission.call_args_list) == 0
     assert len(mission_tracking.inorbit_sess.publish_key_values.call_args_list) == 0
@@ -109,6 +109,7 @@ class TestSafeLocalizeTimestamp:
             mir_api=MagicMock(autospec=MirApiV2),
             inorbit_sess=MagicMock(autospec=RobotSession),
             robot_tz_info=pytz.timezone("America/Los_Angeles"),
+            mission_executor=MagicMock(),
         )
 
     def test_timestamp_without_timezone_info(self, pst_mission_tracking):
@@ -155,6 +156,7 @@ class TestSafeLocalizeTimestamp:
             mir_api=MagicMock(autospec=MirApiV2),
             inorbit_sess=MagicMock(autospec=RobotSession),
             robot_tz_info=pytz.timezone("UTC"),
+            mission_executor=MagicMock(),
         )
 
         # Timestamp without timezone should get UTC applied


### PR DESCRIPTION
## Problem

Missions were being tracked twice: the same mission appeared as two separate entries. The MiR connector has two independent mission-reporting paths — robot-side polling (`MirInorbitMissionTracking`) and the InOrbit edge mission executor — and the guard meant to keep them mutually exclusive was checking the wrong executor.

The guard checked `session.missions_module.executor` (the legacy `inorbit-edge` SDK executor, driven by the `runMission` command). InOrbit-dispatched missions, however, run through the `inorbit-edge-executor` worker pool via the `executeMissionAction` command, which leaves the legacy executor idle. So the guard never engaged and robot-side polling reported the same mission a second time.

## Previous attempt

#90 ("InOrbit MT only works when edge executor is idle") introduced this guard, replacing an explicit enable/disable flag with the idle check. It polled the legacy executor, so it never covered missions dispatched through the new `inorbit-edge-executor` path — this PR redirects the check at that executor.

## Fix

Gate robot-side polling on the executor that actually runs dispatched missions:

- Add `MirMissionExecutor.has_active_mission()`, backed by the persisted busy-check the worker pool itself uses (`fetch_robot_active_mission`) — accurate even after a mission finishes, unlike the in-memory worker set.
- Use it in `report_mission()` instead of the legacy executor check.
- Apply the same signal to the `mode_text`/`state_text` selection in the execution loop, which had the same stale check.
- Add a regression test asserting robot-side tracking stays silent while a dispatched mission is active.

No framework change required — `fetch_robot_active_mission` already ships in the pinned `inorbit-edge-executor`.

## Testing

- `pytest` connector suite: 88 passed
- flake8 clean