### PR TITLE
Bump mir_connector version: 2.1.0 → 2.2.0

### DIFF
--- a/mir_connector/.bumpversion.toml
+++ b/mir_connector/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2.1.0"
+current_version = "2.2.0"
 commit = true
 message = "Bump mir_connector version: {current_version} → {new_version}"
 tag = true

--- a/mir_connector/inorbit_mir_connector/__init__.py
+++ b/mir_connector/inorbit_mir_connector/__init__.py
@@ -6,7 +6,7 @@ __author__ = "InOrbit"
 __email__ = "support@inorbit.ai"
 # Do not edit this string manually, always use bump-my-version
 # See https://github.com/inorbit-ai/inorbit-robot-connectors/tree/main/mir_connector#version-bump
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 
 def get_module_version():

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -81,5 +81,5 @@ setup(
     python_requires=">=3.10",
     # Do not edit this string manually, always use bump-my-version. See
     # https://github.com/inorbit-ai/inorbit-robot-connectors/tree/main/mir_connector#version-bump
-    version="2.1.0",
+    version="2.2.0",
 )


### PR DESCRIPTION
Bumps `mir_connector` version from **2.1.0** to **2.2.0** via `bump-my-version`.

Updated files:
- `.bumpversion.toml`
- `setup.py`
- `inorbit_mir_connector/__init__.py`

Signed tag `mir_connector-v2.2.0` has been pushed.