### PR TITLE
MiR connector: Upgrade Connect SDK dependencies

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -3,30 +3,30 @@
 # SPDX-License-Identifier: MIT
 
 import base64
-import pytz
 import math
 import uuid
 
+import pytz
+from inorbit_connector.commands import CommandResultCode
+
 # from typing import override # TODO(b-Tomas): Uncomment when updating to Python 3.13
 from inorbit_connector.connector import Connector
-from inorbit_connector.commands import CommandResultCode
 from inorbit_connector.models import MapConfigTemp
-from inorbit_edge.robot import COMMAND_CUSTOM_COMMAND
-from inorbit_edge.robot import COMMAND_MESSAGE
-from inorbit_edge.robot import COMMAND_NAV_GOAL
+from inorbit_edge.robot import COMMAND_CUSTOM_COMMAND, COMMAND_MESSAGE, COMMAND_NAV_GOAL
+from inorbit_edge_executor.inorbit import InOrbitAPI as MissionInOrbitAPI
+
 from inorbit_mir_connector import get_module_version
 from inorbit_mir_connector.src.mir_api.missions_group import (
     NullMissionsGroupHandler,
     TmpMissionsGroupHandler,
 )
-from .mir_api import MirApiV2
-from .mir_api import SetStateId
-from .mission_tracking import MirInorbitMissionTracking
-from .mission_exec import MirMissionExecutor
-from inorbit_edge_executor.inorbit import InOrbitAPI as MissionInOrbitAPI
+
 from ..config.connector_model import ConnectorConfig
+from .mir_api import MirApiV2, SetStateId
+from .mission_exec import MirMissionExecutor
+from .mission_tracking import MirInorbitMissionTracking
 from .robot.robot import Robot
-from .utils import to_inorbit_percent, calculate_usage_percent
+from .utils import calculate_usage_percent, to_inorbit_percent
 
 # Available MiR states to select via actions
 MIR_STATE = {3: "READY", 4: "PAUSE", 11: "MANUALCONTROL"}
@@ -125,7 +125,11 @@ class MirConnector(Connector):
 
         # Set up temporary mission groups
         if self._robot_config.enable_temporary_mission_group:
-            self.mission_group = TmpMissionsGroupHandler(mir_api=self.mir_api)
+            self.mission_group = TmpMissionsGroupHandler(
+                mir_api=self.mir_api,
+                create_supervised_task=self._create_supervised_task,
+                spawn_logged_task=self._spawn_logged_task,
+            )
         else:
             self.mission_group = NullMissionsGroupHandler()
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/missions_group.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/missions_group.py
@@ -3,18 +3,19 @@
 # SPDX-License-Identifier: MIT
 
 import asyncio
-from abc import ABC, abstractmethod
-
-from .mir_api_v2 import MirApiV2
-from tenacity import (
-    retry,
-    wait_exponential_jitter,
-    before_sleep_log,
-    retry_if_exception_type,
-)
-import httpx
 import logging
 import uuid
+from abc import ABC, abstractmethod
+
+import httpx
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    wait_exponential_jitter,
+)
+
+from .mir_api_v2 import MirApiV2
 
 
 class MirMissionsGroupHandler(ABC):
@@ -80,11 +81,28 @@ class TmpMissionsGroupHandler(MirMissionsGroupHandler):
     # Remove missions created in the temporary missions group every 6 hours
     MISSIONS_GARBAGE_COLLECTION_INTERVAL_SECS = 6 * 60 * 60
 
-    def __init__(self, mir_api: MirApiV2):
+    def __init__(self, mir_api: MirApiV2, create_supervised_task=None, spawn_logged_task=None):
+        """Initialize the temporary missions group handler.
+
+        Args:
+            mir_api: MiR REST API client.
+            create_supervised_task: Scheduler for the garbage-collection loop. The connector
+                injects a supervisor that re-runs the loop on crash; defaults to bare
+                ``asyncio.create_task``.
+            spawn_logged_task: Scheduler for one-shot setup. The connector injects a wrapper that
+                logs failures instead of swallowing them; defaults to bare ``asyncio.create_task``.
+        """
         super().__init__()
 
         self.mir_api = mir_api
         self._logger = logging.getLogger(name=self.__class__.__name__)
+
+        self._create_supervised_task = create_supervised_task or (
+            lambda name, coro_factory: asyncio.create_task(coro_factory())
+        )
+        self._spawn_logged_task = spawn_logged_task or (
+            lambda name, coro: asyncio.create_task(coro)
+        )
 
         # Missions group id for temporary missions
         # If None, it indicates the missions group has not been set up
@@ -101,9 +119,14 @@ class TmpMissionsGroupHandler(MirMissionsGroupHandler):
 
     async def start(self):
         """Start the temporary missions group."""
-        # Start async setup and garbage collection for missions
-        self._bg_tasks.append(asyncio.create_task(self.setup_connector_missions()))
-        self._bg_tasks.append(asyncio.create_task(self._missions_garbage_collector()))
+        # Setup runs once; the garbage collector loops forever, so it is passed as a factory the
+        # supervisor can re-create on restart.
+        self._bg_tasks.append(
+            self._spawn_logged_task("missions-group-setup", self.setup_connector_missions())
+        )
+        self._bg_tasks.append(
+            self._create_supervised_task("missions-gc", self._missions_garbage_collector)
+        )
 
     async def stop(self):
         """Stop the temporary missions group."""

--- a/mir_connector/inorbit_mir_connector/tests/test_missions_group.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_missions_group.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2025 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for ``TmpMissionsGroupHandler`` background-task scheduling.
+
+``start()`` routes setup through the one-shot logged-task helper and the garbage-collection loop
+through the supervised-task helper, and falls back to bare ``asyncio.create_task`` when neither
+is injected.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def mir_api():
+    api = MagicMock()
+    api.get_mission_groups = AsyncMock(return_value=[])
+    api.create_mission_group = AsyncMock()
+    return api
+
+
+@pytest.mark.asyncio
+async def test_start_routes_through_injected_task_helpers(mir_api):
+    """start() routes setup -> spawn_logged_task and GC -> create_supervised_task."""
+    from inorbit_mir_connector.src.mir_api.missions_group import TmpMissionsGroupHandler
+
+    created_supervised = []
+    spawned_logged = []
+
+    def fake_supervised(name, factory):
+        created_supervised.append((name, factory))
+        return MagicMock()
+
+    def fake_logged(name, coro):
+        spawned_logged.append((name, coro))
+        coro.close()  # avoid "coroutine was never awaited" warning
+        return MagicMock()
+
+    handler = TmpMissionsGroupHandler(
+        mir_api=mir_api,
+        create_supervised_task=fake_supervised,
+        spawn_logged_task=fake_logged,
+    )
+    await handler.start()
+
+    # One-shot setup goes through the logged-task helper.
+    assert len(spawned_logged) == 1
+    setup_name, _setup_coro = spawned_logged[0]
+    assert setup_name == "missions-group-setup"
+
+    # Long-lived GC loop goes through the supervised-task helper, passing the bound method as the
+    # zero-arg coroutine factory (so it is re-created on each restart).
+    assert len(created_supervised) == 1
+    gc_name, gc_factory = created_supervised[0]
+    assert gc_name == "missions-gc"
+    assert gc_factory == handler._missions_garbage_collector
+
+
+@pytest.mark.asyncio
+async def test_start_defaults_to_bare_create_task(mir_api):
+    """Without injected helpers, start() falls back to bare asyncio.create_task."""
+    from inorbit_mir_connector.src.mir_api.missions_group import TmpMissionsGroupHandler
+
+    handler = TmpMissionsGroupHandler(mir_api=mir_api)
+    await handler.start()
+
+    assert len(handler._bg_tasks) == 2
+    assert all(isinstance(t, asyncio.Task) for t in handler._bg_tasks)
+
+    await handler.stop()
+    assert handler._bg_tasks == []

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -23,7 +23,6 @@ requirements = [
     "tenacity>=9.1.2",
     # InOrbit
     "inorbit-edge[video]~=3.1",
-    # >=3.2 is required for the supervised background-task helpers the missions-group handler uses.
     "inorbit-connector[video]>=3.2,<4.0",
     "inorbit-edge-executor~=4.0.3",
 ]

--- a/mir_connector/setup.py
+++ b/mir_connector/setup.py
@@ -12,21 +12,19 @@ requirements = [
     # via ``opentelemetry-exporter-prometheus`` (a dep of inorbit-connector),
     # but we declare it explicitly because the import is direct.
     "prometheus-client>=0.25,<1.0",
-    "pytz>=2022.7",
+    "pytz>=2025.1",
     # NOTE: both pyyaml and ruamel.yaml packages are included here. Otherwise, the
     # edge-sdk dependency won't run. Consider migrating edge-sdk yaml dependency
     # to ruamel.yaml or fix the dependency issue and then remove pyyaml from here.
-    "pyyaml>=6.0,<6.1",
+    "pyyaml~=6.0.2",
     "ruamel.yaml>=0.18,<0.19",
     "pydantic>=2.11,<3",
-    "pydantic-settings>=2.11,<3",
+    "pydantic-settings>=2.14,<3",
     "tenacity>=9.1.2",
-    # InOrbit. The ``[video]`` extra on inorbit-connector pulls
-    # ``inorbit-edge[video]>=3.0,<4`` transitively, so we don't declare
-    # inorbit-edge separately. >=3.1 is required for the
-    # ``inorbit_connector.metrics`` module.
-    "inorbit-connector[video]>=3.1,<4.0",
-    "inorbit-edge-executor~=3.2.5",
+    # The ``[video]`` extra pulls inorbit-edge transitively, so we don't declare it separately.
+    # >=3.2 is required for the supervised background-task helpers the missions-group handler uses.
+    "inorbit-connector[video]>=3.2,<4.0",
+    "inorbit-edge-executor~=4.0.3",
 ]
 
 test_requirements = [


### PR DESCRIPTION
Upgrades the MiR connector's InOrbit Connect SDK stack ahead of implementing native mission execution.

| Package | Before | After |
|---|---|---|
| `inorbit-edge-executor` | `~=3.2.5` | `~=4.0.3` |
| `inorbit-connector[video]` | `>=3.1,<4.0` | `>=3.2,<4.0` |

The executor jump is a major version bump; the connector bump is minor. `inorbit-edge` stays at `~=3.1` (already on main) and resolves to 3.1.0. The resolved environment is executor 4.0.3 / connector 3.2.0 / edge 3.1.0, and `pip check` is clean. Transitive floors the connector now requires were aligned: `pydantic-settings>=2.14`, `pyyaml~=6.0.2`, `pytz>=2025.1`.

Connector 3.2.0 adds supervised background-task helpers (`_create_supervised_task` / `_spawn_logged_task`), now used by `TmpMissionsGroupHandler`:

- Mission-group setup runs as a logged one-shot task. A non-retryable failure previously died silently on an un-awaited task, leaving `missions_group_id` unset with no log; it is now surfaced.
- The garbage-collection loop runs supervised and is restarted on crash.

The helpers are injected from the connector with a bare-`create_task` fallback, so the handler still works when constructed standalone. `Robot._run_in_loop` was left unchanged — it already recovers per-iteration (try/except, circuit breaker, backoff), which covers more than supervised restart.

`inorbit-edge` 3.1.0 also brings non-blocking camera streaming, a 10s→60s MQTT keepalive, and guarded MQTT callbacks, with no connector changes required.

Behavior note: native mission translation is not wired yet, so the stock tree still runs edge-dispatched missions. Executor 4.0.x changes their abort reporting — state `abandoned`→`aborted`, and default cancel/abort status `ok`→`error`. No existing test asserts these values; the `ok` status will be restored when the native mission tree lands.

Testing: full suite passes (90 tests, including 2 new in `test_missions_group.py` covering the task-helper routing and the bare-`create_task` fallback). flake8 and black are clean at line length 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
