### PR TITLE
MiR connector: native InOrbit to MiR mission translation

### DIFF
--- a/mir_connector/inorbit_mir_connector/inorbit_mir_connector.py
+++ b/mir_connector/inorbit_mir_connector/inorbit_mir_connector.py
@@ -32,6 +32,7 @@ def setup_logging():
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("asyncio").setLevel(logging.WARNING)
+    logging.getLogger("aiosqlite").setLevel(logging.WARNING)
 
     # Reduce noise from InOrbit SDK - these log every MQTT publish
     logging.getLogger("inorbit_edge.robot").setLevel(logging.INFO)

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -113,17 +113,9 @@ class MirConnector(Connector):
         # ``HttpUrl``; cast to str because ``MissionInOrbitAPI``
         # concatenates it with str paths — strip the trailing slash
         # HttpUrl normalization adds so joined paths don't double it).
-        self.mission_executor: MirMissionExecutor = MirMissionExecutor(
-            robot_id=robot_id,
-            inorbit_api=MissionInOrbitAPI(
-                base_url=str(self.config.api_url).rstrip("/"),
-                api_key=self.config.api_key,
-            ),
-            mir_api=self.mir_api,
-            database_file=self._robot_config.mission_database_file,
-        )
-
-        # Set up temporary mission groups
+        # Set up temporary mission groups. Built before the mission executor:
+        # native-mission translation creates its MiR missions inside this group,
+        # so the executor needs the handler at construction time.
         if self._robot_config.enable_temporary_mission_group:
             self.mission_group = TmpMissionsGroupHandler(
                 mir_api=self.mir_api,
@@ -132,6 +124,19 @@ class MirConnector(Connector):
             )
         else:
             self.mission_group = NullMissionsGroupHandler()
+
+        self.mission_executor: MirMissionExecutor = MirMissionExecutor(
+            robot_id=robot_id,
+            inorbit_api=MissionInOrbitAPI(
+                base_url=str(self.config.api_url).rstrip("/"),
+                api_key=self.config.api_key,
+            ),
+            mir_api=self.mir_api,
+            database_file=self._robot_config.mission_database_file,
+            missions_group=self.mission_group,
+            firmware_version=self._robot_config.mir_firmware_version,
+            connector_type=self.config.connector_type,
+        )
 
         # Initialize status as None to prevent publishing before the robot is connected
         self.status = None

--- a/mir_connector/inorbit_mir_connector/src/mir_api/__init__.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/__init__.py
@@ -1,1 +1,6 @@
-from .mir_api_v2 import MirApiV2, SetStateId  # noqa: F401
+from .mir_api_v2 import (  # noqa: F401
+    DockingOffsetError,
+    MirApiV2,
+    SetStateId,
+    resolve_marker_type,
+)

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
@@ -178,6 +178,29 @@ class MirApiBaseClass(ABC):
                     duration_seconds=duration,
                 )
 
+    async def _request(self, method: str, endpoint: str, **kwargs) -> httpx.Response:
+        """Issue a request and surface the MiR error body on failure.
+
+        Sits between the retrying verb wrappers and the metrics-only
+        ``_record_request``. ``HTTPStatusError.str()`` carries only the status
+        line ("Client error '400 Bad Request' for url ..."); MiR puts the
+        actual reason a request was rejected (e.g. an invalid mission action
+        parameter) in the response body, which would otherwise never reach the
+        logs or the mission abort reason.
+        """
+        try:
+            return await self._record_request(method, endpoint, **kwargs)
+        except httpx.HTTPStatusError as e:
+            body = e.response.text
+            self.logger.warning(
+                "MiR API %s %s -> %s: %s",
+                method,
+                endpoint,
+                e.response.status_code,
+                (body[:2000] if body else "<empty response body>"),
+            )
+            raise
+
     @retry(
         wait=wait_exponential_jitter(initial=1, max=10),
         stop=stop_after_attempt(3),
@@ -186,7 +209,7 @@ class MirApiBaseClass(ABC):
         reraise=True,
     )
     async def _get(self, endpoint: str, **kwargs) -> httpx.Response:
-        return await self._record_request("GET", endpoint, **kwargs)
+        return await self._request("GET", endpoint, **kwargs)
 
     @retry(
         wait=wait_exponential_jitter(initial=1, max=10),
@@ -196,7 +219,7 @@ class MirApiBaseClass(ABC):
         reraise=True,
     )
     async def _post(self, endpoint: str, **kwargs) -> httpx.Response:
-        return await self._record_request("POST", endpoint, **kwargs)
+        return await self._request("POST", endpoint, **kwargs)
 
     @retry(
         wait=wait_exponential_jitter(initial=1, max=10),
@@ -206,7 +229,7 @@ class MirApiBaseClass(ABC):
         reraise=True,
     )
     async def _put(self, endpoint: str, **kwargs) -> httpx.Response:
-        return await self._record_request("PUT", endpoint, **kwargs)
+        return await self._request("PUT", endpoint, **kwargs)
 
     @retry(
         wait=wait_exponential_jitter(initial=1, max=10),
@@ -216,7 +239,7 @@ class MirApiBaseClass(ABC):
         reraise=True,
     )
     async def _delete(self, endpoint: str, **kwargs) -> httpx.Response:
-        return await self._record_request("DELETE", endpoint, **kwargs)
+        return await self._request("DELETE", endpoint, **kwargs)
 
     async def close(self):
         await self._async_client.aclose()

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
@@ -255,6 +255,11 @@ class MirApiBaseClass(ABC):
         pass
 
     @abstractmethod
+    async def abort_mission(self, mission_queue_id):
+        """Aborts a single mission from the mission queue by its mission_queue id"""
+        pass
+
+    @abstractmethod
     async def queue_mission(self, mission_id: str):
         """Receives a mission ID and sends a request to append it to the robot's mission queue"""
         pass

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -3,21 +3,23 @@
 # SPDX-License-Identifier: MIT
 
 import hashlib
-import math
 import logging
+import math
 import time
-import httpx
 from enum import Enum
 from typing import Optional
-from prometheus_client import parser
 
+import httpx
 from inorbit_connector.metrics.http import (
     record_upstream_http_error,
     record_upstream_http_request,
 )
 from inorbit_edge.missions import MISSION_STATE_EXECUTING
+from prometheus_client import parser
+
 from inorbit_mir_connector.config.connector_model import CONNECTOR_TYPE
 from inorbit_mir_connector.src.metrics import error_kind
+
 from .mir_api_base import MirApiBaseClass
 
 API_V2_CONTEXT_URL = "/api/v2.0.0"
@@ -29,6 +31,7 @@ MISSION_GROUPS_ENDPOINT_V2 = "mission_groups"
 MISSIONS_ENDPOINT_V2 = "missions"
 STATUS_ENDPOINT_V2 = "status"
 DIAGNOSTICS_ENDPOINT_V2 = "experimental/diagnostics"
+POSITIONS_ENDPOINT_V2 = "positions"
 
 
 class SetStateId(int, Enum):
@@ -188,6 +191,16 @@ class MirApiV2(MirApiBaseClass):
         response = await self._get(missions_api_url)
         return response.json()
 
+    async def get_mission_queue_entry(self, queue_id):
+        """Return full details of a single mission queue entry.
+
+        Single ``GET /mission_queue/{id}`` — distinct from the heavyweight
+        ``get_mission`` (which composes four GETs), so it is light enough for
+        the ~1 s native-mission completion poll.
+        """
+        mission_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{queue_id}"
+        return (await self._get(mission_api_url)).json()
+
     async def get_executing_mission_id(self):
         """Returns the id of the mission being currently executed by the robot"""
         missions_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}"
@@ -227,6 +240,7 @@ class MirApiV2(MirApiBaseClass):
             json=mission_queues,
         )
         self.logger.debug(f"Mission queued: {response.text}")
+        return response.json()
 
     async def abort_all_missions(self):
         """Aborts all missions"""
@@ -332,3 +346,70 @@ class MirApiV2(MirApiBaseClass):
         """
         response = await self._get(f"maps/{map_id}")
         return response.json()
+
+    async def get_position_docking_offsets(self, position_guid: str) -> list:
+        """Return the docking offsets attached to a position.
+
+        Each offset record carries a ``guid``. Positions with no offset
+        configured (e.g. most chargers) return an empty list.
+        """
+        offsets_api_url = f"/{POSITIONS_ENDPOINT_V2}/{position_guid}/docking_offsets"
+        return (await self._get(offsets_api_url)).json()
+
+
+# Ported from the Mappalink MiR connector (mir_connector/src/mir_api/mir_api.py:292-344,
+# commit c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925) for the vendored mission module, which
+# imports DockingOffsetError / resolve_marker_type from this package. SPDX: MIT.
+class DockingOffsetError(Exception):
+    """A ``docking`` action's ``marker_type`` could not be resolved.
+
+    Raised when a docking action gives a ``marker`` but no ``marker_type`` and
+    the connector cannot fill it in — the position has no docking offset, or
+    the offset lookup failed. MiR rejects an offsetless docking action, so
+    failing here surfaces a clear cause instead of an opaque downstream HTTP
+    400.
+    """
+
+
+async def resolve_marker_type(
+    mir_api: MirApiV2,
+    action_type: str,
+    parameters: dict,
+    log: logging.Logger,
+) -> dict:
+    """Fill in ``marker_type`` for a MiR ``docking`` action.
+
+    MiR's ``docking`` action takes two correlated GUIDs: ``marker`` (the
+    target position) and ``marker_type`` (that position's docking-offset
+    record). A position has at most one offset, so ``marker_type`` can be
+    derived from ``marker`` alone.
+
+    Returns a copy of ``parameters`` with ``marker_type`` filled in. Raises
+    ``DockingOffsetError`` when the marker has no docking offset, or when the
+    offset lookup fails — MiR rejects an offsetless docking action, so failing
+    here gives a clear cause rather than an opaque downstream HTTP 400.
+
+    Non-docking actions, and docking actions whose ``marker_type`` is already
+    set to a non-empty value, pass through unchanged.
+    """
+    if action_type != "docking":
+        return parameters
+    marker = parameters.get("marker")
+    if not marker or parameters.get("marker_type"):
+        return parameters
+
+    try:
+        offsets = await mir_api.get_position_docking_offsets(marker)
+        guid = offsets[0]["guid"] if offsets else None
+    except Exception as ex:
+        raise DockingOffsetError(
+            f"docking: could not look up the docking offset for marker {marker}: {ex}"
+        ) from ex
+    if not guid:
+        raise DockingOffsetError(
+            f"docking: marker {marker} has no docking offset configured on the "
+            f"robot — MiR requires marker_type for docking; configure an offset "
+            f"for this position"
+        )
+    log.info(f"docking: resolved marker_type {guid} for marker {marker}")
+    return {**parameters, "marker_type": guid}

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -199,7 +199,8 @@ class MirApiV2(MirApiBaseClass):
         the ~1 s native-mission completion poll.
         """
         mission_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{queue_id}"
-        return (await self._get(mission_api_url)).json()
+        response = await self._get(mission_api_url)
+        return response.json()
 
     async def get_executing_mission_id(self):
         """Returns the id of the mission being currently executed by the robot"""
@@ -368,7 +369,8 @@ class MirApiV2(MirApiBaseClass):
         configured (e.g. most chargers) return an empty list.
         """
         offsets_api_url = f"/{POSITIONS_ENDPOINT_V2}/{position_guid}/docking_offsets"
-        return (await self._get(offsets_api_url)).json()
+        response = await self._get(offsets_api_url)
+        return response.json()
 
 
 # Ported from the Mappalink MiR connector (mir_connector/src/mir_api/mir_api.py:292-344,

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -251,6 +251,20 @@ class MirApiV2(MirApiBaseClass):
         )
         self.logger.debug(f"Missions aborted: {response.text}")
 
+    async def abort_mission(self, mission_queue_id):
+        """Aborts a single mission queue entry.
+
+        ``DELETE /mission_queue/{id}`` aborts only the specified mission (pending or
+        executing) and leaves the rest of the queue intact, unlike
+        ``abort_all_missions`` which clears the whole queue.
+        """
+        queue_entry_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{mission_queue_id}"
+        response = await self._delete(
+            queue_entry_url,
+            headers={"Content-Type": "application/json"},
+        )
+        self.logger.debug(f"Mission {mission_queue_id} aborted: {response.text}")
+
     async def set_state(self, state_id: int):
         """Set robot state
 

--- a/mir_connector/inorbit_mir_connector/src/mission/CLAUDE.md
+++ b/mir_connector/inorbit_mir_connector/src/mission/CLAUDE.md
@@ -1,0 +1,18 @@
+# src/mission: vendored module (do not edit casually)
+
+This package is vendored **verbatim** from the Mappalink MiR connector:
+- Repo: https://github.com/mappalink/inorbit-mir-connector
+- Pinned commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+- Upstream path: mir_connector/src/mission/
+
+## Rules for changing files in this directory
+
+1. **Log every edit in the file header.** Each file has a `# Modifications from upstream` block
+   under its SPDX header. Append `- <YYYY-MM-DD> <author>: <what changed and why>` for ANY change.
+2. **Keep SPDX headers** (`SPDX-FileCopyrightText: 2026 Mappalink`, `SPDX-License-Identifier: MIT`).
+3. **Do not reformat or relint** vendored files, because it destroys the upstream diff. Functional
+   changes only.
+4. **Prefer not to edit here.** Subclass/wrap in connector code (`src/mission_exec.py`,
+   `src/mir_api/`) instead. Edit a vendored file only when there is no clean override point.
+5. **Re-syncing with upstream:** diff this dir against the pinned commit, bump the pin above,
+   re-apply each recorded modification, update headers.

--- a/mir_connector/inorbit_mir_connector/src/mission/__init__.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/mir_connector/src/mission/__init__.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -10,6 +10,7 @@
 #   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
 #   - 2026-06-26: MirApi -> MirApiV2 (our class is MirApiV2; no alias) in import + type hints
 #   - 2026-06-26: added "# noqa: E501" to one long line (vendored ruff style, not relinted)
+#   - 2026-06-26: StrEnum import fallback for Python 3.10 (enum.StrEnum added in 3.11)
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -26,7 +27,16 @@ import asyncio
 import logging
 import time
 import uuid
-from enum import StrEnum
+
+try:
+    from enum import StrEnum  # Python >= 3.11
+except ImportError:  # Python 3.10
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+
 from typing import Optional
 
 from inorbit_edge_executor.behavior_tree import (

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/mir_connector/src/mission/behavior_tree.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - 2026-06-26: rebased intra-package import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+
+"""Custom behavior tree nodes for executing compiled native MiR missions.
+
+The tree for a single MissionStepExecuteMirNativeMission step:
+
+    BehaviorTreeSequential("Navigate N waypoints")
+      +-- CreateMirNativeMissionNode   -> create_mission + N x add_action + queue
+      +-- WaitForMirMissionCompletionNode -> poll mission_queue until Done/Abort
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from enum import StrEnum
+from typing import Optional
+
+from inorbit_edge_executor.behavior_tree import (
+    BehaviorTree,
+    BehaviorTreeBuilderContext,
+    BehaviorTreeSequential,
+    MissionAbortedNode,
+    NodeFromStepBuilder,
+    register_accepted_node_types,
+)
+from inorbit_edge_executor.inorbit import MissionStatus
+
+from inorbit_mir_connector.src.mission.datatypes import (
+    MirAction,
+    MirWaypoint,
+    MissionStepExecuteMirNativeMission,
+)
+from inorbit_mir_connector.src.mir_api import DockingOffsetError, MirApi, resolve_marker_type
+
+logger = logging.getLogger(__name__)
+
+# Distance threshold for MiR move missions (meters)
+_MIR_MOVE_DISTANCE_THRESHOLD = 0.1
+
+# Polling interval for mission queue state checks
+_POLL_INTERVAL_SECS = 1.0
+
+# MiR mission queue states
+_STATE_DONE = "Done"
+_STATE_ABORT = "Aborted"
+
+
+class SharedMemoryKeys(StrEnum):
+    MIR_MISSION_GUID = "mir_mission_guid"
+    MIR_QUEUE_ID = "mir_queue_id"
+    MIR_ERROR_MESSAGE = "mir_error_message"
+
+
+class MirBehaviorTreeBuilderContext(BehaviorTreeBuilderContext):
+    """Extended context carrying MiR API, missions group ID, and firmware version."""
+
+    def __init__(
+        self,
+        mir_api: MirApi,
+        missions_group_id: Optional[str],
+        firmware_version: str,
+        connector_type: str = "",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._mir_api = mir_api
+        self._missions_group_id = missions_group_id
+        self._firmware_version = firmware_version
+        self._connector_type = connector_type
+
+    @property
+    def mir_api(self) -> MirApi:
+        return self._mir_api
+
+    @property
+    def missions_group_id(self) -> Optional[str]:
+        return self._missions_group_id
+
+    @property
+    def firmware_version(self) -> str:
+        return self._firmware_version
+
+    @property
+    def connector_type(self) -> str:
+        return self._connector_type
+
+
+class CreateMirNativeMissionNode(BehaviorTree):
+    """Creates a native MiR mission with move_to_position actions and queues it."""
+
+    def __init__(
+        self,
+        context: MirBehaviorTreeBuilderContext,
+        step: MissionStepExecuteMirNativeMission,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._mir_api = context.mir_api
+        self._missions_group_id = context.missions_group_id
+        self._firmware_version = context.firmware_version
+        self._shared_memory = context.shared_memory
+        self._step = step
+
+        self._shared_memory.add(SharedMemoryKeys.MIR_MISSION_GUID, None)
+        self._shared_memory.add(SharedMemoryKeys.MIR_QUEUE_ID, None)
+        self._shared_memory.add(SharedMemoryKeys.MIR_ERROR_MESSAGE, None)
+
+    async def _execute(self):
+        actions = self._step.actions
+        n = len(actions)
+        mission_guid = str(uuid.uuid4())
+
+        logger.info(f"Creating MiR native mission with {n} actions: {mission_guid}")
+
+        if not self._missions_group_id:
+            error_msg = "No missions group available for creating native MiR mission"
+            logger.error(error_msg)
+            self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
+            raise RuntimeError(error_msg)
+
+        try:
+            await self._mir_api.create_mission(
+                group_id=self._missions_group_id,
+                name=f"InOrbit Mission ({n} actions)",
+                guid=mission_guid,
+                description="Compiled mission created by InOrbit edge executor",
+            )
+
+            for i, action in enumerate(actions):
+                if isinstance(action, MirWaypoint):
+                    action_type = "move_to_position"
+                    param_values = {
+                        "x": action.x,
+                        "y": action.y,
+                        "orientation": action.orientation,
+                        "distance_threshold": _MIR_MOVE_DISTANCE_THRESHOLD,
+                    }
+                    if self._firmware_version == "v2":
+                        param_values["retries"] = 5
+                    else:
+                        param_values["blocked_path_timeout"] = 60.0
+                elif isinstance(action, MirAction):
+                    action_type = action.action_type
+                    param_values = dict(action.parameters)
+                else:
+                    raise TypeError(f"Unexpected action type: {type(action)}")
+
+                param_values = await resolve_marker_type(
+                    self._mir_api, action_type, param_values, logger
+                )
+
+                action_parameters = [
+                    {"value": v, "input_name": None, "guid": str(uuid.uuid4()), "id": k}
+                    for k, v in param_values.items()
+                ]
+
+                await self._mir_api.add_action_to_mission(
+                    action_type=action_type,
+                    mission_id=mission_guid,
+                    parameters=action_parameters,
+                    priority=i + 1,
+                )
+
+            queue_response = await self._mir_api.queue_mission(mission_guid)
+            queue_id = queue_response.get("id")
+            self._shared_memory.set(SharedMemoryKeys.MIR_MISSION_GUID, mission_guid)
+            self._shared_memory.set(SharedMemoryKeys.MIR_QUEUE_ID, queue_id)
+            logger.info(f"Queued MiR native mission: {mission_guid} (queue id: {queue_id})")
+
+        except DockingOffsetError as e:
+            # Already a clear, operator-facing message — surface it as-is.
+            error_msg = str(e)
+            logger.error(error_msg)
+            self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
+            raise RuntimeError(error_msg) from e
+        except Exception as e:
+            error_msg = f"Failed to create/queue MiR native mission: {e}"
+            logger.error(error_msg)
+            self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
+            raise RuntimeError(error_msg) from e
+
+    def dump_object(self):
+        obj = super().dump_object()
+        obj["step"] = self._step.model_dump(mode="json", exclude_none=True)
+        return obj
+
+    @classmethod
+    def from_object(cls, context, step, **kwargs):
+        if isinstance(step, dict):
+            step = MissionStepExecuteMirNativeMission.model_validate(step)
+        return CreateMirNativeMissionNode(context, step, **kwargs)
+
+
+class WaitForMirMissionCompletionNode(BehaviorTree):
+    """Polls MiR mission queue until the queued native mission completes."""
+
+    def __init__(
+        self,
+        context: MirBehaviorTreeBuilderContext,
+        timeout_secs: Optional[float] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._mir_api = context.mir_api
+        self._shared_memory = context.shared_memory
+        self._timeout_secs = timeout_secs
+
+    async def _execute(self):
+        queue_id = self._shared_memory.get(SharedMemoryKeys.MIR_QUEUE_ID)
+        mission_guid = self._shared_memory.get(SharedMemoryKeys.MIR_MISSION_GUID)
+        if not queue_id:
+            raise RuntimeError("No MiR queue ID in shared memory")
+
+        logger.info(
+            f"Waiting for MiR mission queue entry {queue_id} (mission {mission_guid}) to complete"
+        )
+        start_time = time.time()
+        consecutive_errors = 0
+        max_consecutive_errors = 10
+
+        while True:
+            if self._timeout_secs and (time.time() - start_time) > self._timeout_secs:
+                raise RuntimeError(f"MiR mission {queue_id} timed out after {self._timeout_secs}s")
+
+            try:
+                entry = await self._mir_api.get_mission_queue_entry(queue_id)
+                consecutive_errors = 0
+            except Exception as e:
+                consecutive_errors += 1
+                logger.warning(
+                    f"Failed to poll mission queue entry {queue_id} "
+                    f"({consecutive_errors}/{max_consecutive_errors}): {e}"
+                )
+                if consecutive_errors >= max_consecutive_errors:
+                    error_msg = f"MiR mission {queue_id} lost: {consecutive_errors} consecutive poll failures"
+                    logger.error(error_msg)
+                    self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
+                    raise RuntimeError(error_msg)
+                await asyncio.sleep(_POLL_INTERVAL_SECS)
+                continue
+
+            state = entry.get("state", "")
+
+            if state == _STATE_DONE:
+                logger.info(f"MiR mission {queue_id} completed successfully")
+                return
+
+            if state == _STATE_ABORT:
+                error_msg = (
+                    f"MiR mission {queue_id} was aborted: {entry.get('message', 'no message')}"
+                )
+                logger.error(error_msg)
+                self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
+                raise RuntimeError(error_msg)
+
+            logger.debug(f"MiR mission {queue_id} state: {state}")
+            await asyncio.sleep(_POLL_INTERVAL_SECS)
+
+    def dump_object(self):
+        obj = super().dump_object()
+        if self._timeout_secs is not None:
+            obj["timeout_secs"] = self._timeout_secs
+        return obj
+
+    @classmethod
+    def from_object(cls, context, timeout_secs=None, **kwargs):
+        return WaitForMirMissionCompletionNode(context, timeout_secs=timeout_secs, **kwargs)
+
+
+class MirMissionAbortedNode(MissionAbortedNode):
+    """Extended abort node that also aborts MiR mission queue."""
+
+    def __init__(
+        self,
+        context: MirBehaviorTreeBuilderContext,
+        status: MissionStatus = MissionStatus.error,
+        **kwargs,
+    ):
+        super().__init__(context, status, **kwargs)
+        self._mir_api = context.mir_api
+        self._shared_memory = context.shared_memory
+
+    async def _execute(self):
+        error_message = self._shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+        if error_message:
+            logger.error(f"MiR mission aborted: {error_message}")
+
+        try:
+            await self._mir_api.abort_all_missions()
+            logger.info("Aborted MiR mission queue")
+        except Exception as e:
+            logger.warning(f"Failed to abort MiR mission queue: {e}")
+
+        await super()._execute()
+
+    @classmethod
+    def from_object(cls, context, status, **kwargs):
+        return MirMissionAbortedNode(context, MissionStatus(status), **kwargs)
+
+
+class CleanupMirMissionNode(BehaviorTree):
+    """Cancels the active MiR mission during cleanup (e.g. on pause)."""
+
+    def __init__(self, context: MirBehaviorTreeBuilderContext, **kwargs):
+        super().__init__(**kwargs)
+        self._mir_api = context.mir_api
+
+    async def _execute(self):
+        logger.info("Cleaning up MiR mission (aborting queue)")
+        try:
+            await self._mir_api.abort_all_missions()
+        except Exception as e:
+            logger.warning(f"Failed to abort MiR missions during cleanup: {e}")
+
+    @classmethod
+    def from_object(cls, context, **kwargs):
+        return CleanupMirMissionNode(context, **kwargs)
+
+
+class MirNodeFromStepBuilder(NodeFromStepBuilder):
+    """Step builder that handles MiR-specific step types."""
+
+    def __init__(self, context: MirBehaviorTreeBuilderContext):
+        super().__init__(context)
+        self._mir_context = context
+
+    def visit_execute_mir_native_mission(
+        self, step: MissionStepExecuteMirNativeMission
+    ) -> BehaviorTree:
+        sequence = BehaviorTreeSequential(label=step.label)
+        sequence.add_node(
+            CreateMirNativeMissionNode(
+                self._mir_context, step, label=f"Create MiR mission '{step.label}'"
+            )
+        )
+        sequence.add_node(
+            WaitForMirMissionCompletionNode(
+                self._mir_context,
+                timeout_secs=step.timeout_secs,
+                label=f"Wait for MiR mission '{step.label}'",
+            )
+        )
+        return sequence
+
+
+# Register node types for serialization/deserialization
+mir_node_types = [
+    CreateMirNativeMissionNode,
+    WaitForMirMissionCompletionNode,
+    MirMissionAbortedNode,
+    CleanupMirMissionNode,
+]
+register_accepted_node_types(mir_node_types)

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -11,6 +11,9 @@
 #   - 2026-06-26: MirApi -> MirApiV2 (our class is MirApiV2; no alias) in import + type hints
 #   - 2026-06-26: added "# noqa: E501" to one long line (vendored ruff style, not relinted)
 #   - 2026-06-26: StrEnum import fallback for Python 3.10 (enum.StrEnum added in 3.11)
+#   - 2026-06-27: replaced _STATE_DONE/_STATE_ABORT string constants with a
+#     MirMissionQueueState(StrEnum) for consistency with connector enums
+#   - 2026-06-27: renamed local n -> n_actions in CreateMirNativeMissionNode._execute
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -64,9 +67,11 @@ _MIR_MOVE_DISTANCE_THRESHOLD = 0.1
 # Polling interval for mission queue state checks
 _POLL_INTERVAL_SECS = 1.0
 
-# MiR mission queue states
-_STATE_DONE = "Done"
-_STATE_ABORT = "Aborted"
+class MirMissionQueueState(StrEnum):
+    """MiR mission queue entry states we act on while polling."""
+
+    DONE = "Done"
+    ABORTED = "Aborted"
 
 
 class SharedMemoryKeys(StrEnum):
@@ -131,10 +136,10 @@ class CreateMirNativeMissionNode(BehaviorTree):
 
     async def _execute(self):
         actions = self._step.actions
-        n = len(actions)
+        n_actions = len(actions)
         mission_guid = str(uuid.uuid4())
 
-        logger.info(f"Creating MiR native mission with {n} actions: {mission_guid}")
+        logger.info(f"Creating MiR native mission with {n_actions} actions: {mission_guid}")
 
         if not self._missions_group_id:
             error_msg = "No missions group available for creating native MiR mission"
@@ -145,7 +150,7 @@ class CreateMirNativeMissionNode(BehaviorTree):
         try:
             await self._mir_api.create_mission(
                 group_id=self._missions_group_id,
-                name=f"InOrbit Mission ({n} actions)",
+                name=f"InOrbit Mission ({n_actions} actions)",
                 guid=mission_guid,
                 description="Compiled mission created by InOrbit edge executor",
             )
@@ -265,11 +270,11 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
 
             state = entry.get("state", "")
 
-            if state == _STATE_DONE:
+            if state == MirMissionQueueState.DONE:
                 logger.info(f"MiR mission {queue_id} completed successfully")
                 return
 
-            if state == _STATE_ABORT:
+            if state == MirMissionQueueState.ABORTED:
                 error_msg = (
                     f"MiR mission {queue_id} was aborted: {entry.get('message', 'no message')}"
                 )

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -7,7 +7,9 @@
 # Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
 #
 # Modifications from upstream:
-#   - 2026-06-26: rebased intra-package import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+#   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+#   - 2026-06-26: MirApi -> MirApiV2 (our class is MirApiV2; no alias) in import + type hints
+#   - 2026-06-26: added "# noqa: E501" to one long line (vendored ruff style, not relinted)
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -42,7 +44,7 @@ from inorbit_mir_connector.src.mission.datatypes import (
     MirWaypoint,
     MissionStepExecuteMirNativeMission,
 )
-from inorbit_mir_connector.src.mir_api import DockingOffsetError, MirApi, resolve_marker_type
+from inorbit_mir_connector.src.mir_api import DockingOffsetError, MirApiV2, resolve_marker_type
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +70,7 @@ class MirBehaviorTreeBuilderContext(BehaviorTreeBuilderContext):
 
     def __init__(
         self,
-        mir_api: MirApi,
+        mir_api: MirApiV2,
         missions_group_id: Optional[str],
         firmware_version: str,
         connector_type: str = "",
@@ -81,7 +83,7 @@ class MirBehaviorTreeBuilderContext(BehaviorTreeBuilderContext):
         self._connector_type = connector_type
 
     @property
-    def mir_api(self) -> MirApi:
+    def mir_api(self) -> MirApiV2:
         return self._mir_api
 
     @property
@@ -244,7 +246,7 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
                     f"({consecutive_errors}/{max_consecutive_errors}): {e}"
                 )
                 if consecutive_errors >= max_consecutive_errors:
-                    error_msg = f"MiR mission {queue_id} lost: {consecutive_errors} consecutive poll failures"
+                    error_msg = f"MiR mission {queue_id} lost: {consecutive_errors} consecutive poll failures"  # noqa: E501
                     logger.error(error_msg)
                     self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
                     raise RuntimeError(error_msg)

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -72,6 +72,7 @@ _MIR_MOVE_DISTANCE_THRESHOLD = 0.1
 # Polling interval for mission queue state checks
 _POLL_INTERVAL_SECS = 1.0
 
+
 class MirMissionQueueState(StrEnum):
     """MiR mission queue entry states we act on while polling."""
 
@@ -353,7 +354,9 @@ class CleanupMirMissionNode(BehaviorTree):
         try:
             await self._mir_api.abort_mission(queue_id)
         except Exception as e:
-            logger.warning(f"Failed to abort MiR mission queue entry {queue_id} during cleanup: {e}")
+            logger.warning(
+                f"Failed to abort MiR mission queue entry {queue_id} during cleanup: {e}"
+            )
 
     @classmethod
     def from_object(cls, context, **kwargs):

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -14,6 +14,11 @@
 #   - 2026-06-27: replaced _STATE_DONE/_STATE_ABORT string constants with a
 #     MirMissionQueueState(StrEnum) for consistency with connector enums
 #   - 2026-06-27: renamed local n -> n_actions in CreateMirNativeMissionNode._execute
+#   - 2026-06-27: scoped abort: MirMissionAbortedNode/CleanupMirMissionNode now call
+#     abort_mission(queue_id) (DELETE /mission_queue/{id}) instead of abort_all_missions,
+#     so other queued/fleet missions survive; no fallback when the queue id is absent
+#   - 2026-06-27: CleanupMirMissionNode.__init__ now stores context.shared_memory (needed
+#     to read the queue id for the scoped abort above)
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -314,11 +319,15 @@ class MirMissionAbortedNode(MissionAbortedNode):
         if error_message:
             logger.error(f"MiR mission aborted: {error_message}")
 
-        try:
-            await self._mir_api.abort_all_missions()
-            logger.info("Aborted MiR mission queue")
-        except Exception as e:
-            logger.warning(f"Failed to abort MiR mission queue: {e}")
+        queue_id = self._shared_memory.get(SharedMemoryKeys.MIR_QUEUE_ID)
+        if queue_id is not None:
+            try:
+                await self._mir_api.abort_mission(queue_id)
+                logger.info(f"Aborted MiR mission queue entry {queue_id}")
+            except Exception as e:
+                logger.warning(f"Failed to abort MiR mission queue entry {queue_id}: {e}")
+        else:
+            logger.warning("No MiR queue id in shared memory; nothing to abort")
 
         await super()._execute()
 
@@ -333,13 +342,18 @@ class CleanupMirMissionNode(BehaviorTree):
     def __init__(self, context: MirBehaviorTreeBuilderContext, **kwargs):
         super().__init__(**kwargs)
         self._mir_api = context.mir_api
+        self._shared_memory = context.shared_memory
 
     async def _execute(self):
-        logger.info("Cleaning up MiR mission (aborting queue)")
+        queue_id = self._shared_memory.get(SharedMemoryKeys.MIR_QUEUE_ID)
+        if queue_id is None:
+            logger.warning("No MiR queue id in shared memory; nothing to clean up")
+            return
+        logger.info(f"Cleaning up MiR mission (aborting queue entry {queue_id})")
         try:
-            await self._mir_api.abort_all_missions()
+            await self._mir_api.abort_mission(queue_id)
         except Exception as e:
-            logger.warning(f"Failed to abort MiR missions during cleanup: {e}")
+            logger.warning(f"Failed to abort MiR mission queue entry {queue_id} during cleanup: {e}")
 
     @classmethod
     def from_object(cls, context, **kwargs):

--- a/mir_connector/inorbit_mir_connector/src/mission/datatypes.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/datatypes.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/mir_connector/src/mission/datatypes.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - none (verbatim; imports use inorbit_edge_executor.* and relative paths only)
+
+"""MiR-specific mission datatypes for mission translation.
+
+Defines custom step types and mission classes used when consecutive
+waypoint steps are compiled into a single native MiR mission.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Union
+
+from pydantic import Field, model_validator
+
+from inorbit_edge_executor.datatypes import (
+    MissionDefinition,
+    MissionStep,
+    MissionStepPoseWaypoint,
+    MissionStepRunAction,
+    MissionStepSetData,
+    MissionStepWait,
+    MissionStepWaitUntil,
+)
+from inorbit_edge_executor.mission import Mission
+
+
+class MirWaypoint(MissionStep):
+    """A single waypoint in MiR-native coordinates.
+
+    Carries x, y (meters) and orientation (degrees) ready to be sent
+    as a ``move_to_position`` action.
+    """
+
+    x: float = Field(description="X coordinate in MiR native frame (meters)")
+    y: float = Field(description="Y coordinate in MiR native frame (meters)")
+    orientation: float = Field(description="Orientation in degrees (MiR convention)")
+
+
+class MirAction(MissionStep):
+    """Generic MiR action with pass-through parameters."""
+
+    action_type: str = Field(description="MiR action type (e.g. 'docking', 'charging', 'wait')")
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class MissionStepExecuteMirNativeMission(MissionStep):
+    """Custom step that executes a compiled native MiR mission.
+
+    Produced by the translator when consecutive waypoint/action steps are
+    grouped. The behavior tree node creates a MiR mission definition, adds
+    one action per entry, and queues it.
+    """
+
+    actions: List[Union[MirWaypoint, MirAction]] = Field(
+        description="Ordered actions for native MiR mission"
+    )
+    robot_id: str = Field(description="InOrbit robot ID")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_waypoints(cls, data):
+        """Backward-compat: accept serialized missions that still use 'waypoints'."""
+        if isinstance(data, dict) and "waypoints" in data and "actions" not in data:
+            data["actions"] = data.pop("waypoints")
+        return data
+
+    def accept(self, visitor):
+        if hasattr(visitor, "visit_execute_mir_native_mission"):
+            return visitor.visit_execute_mir_native_mission(self)
+        if hasattr(visitor, "collect_step"):
+            return visitor.collect_step(self)
+        return None
+
+
+# Type alias for MiR-specific steps list
+MirStepsList = List[
+    Union[
+        MissionStepSetData,
+        MissionStepPoseWaypoint,
+        MissionStepRunAction,
+        MissionStepWait,
+        MissionStepWaitUntil,
+        MissionStepExecuteMirNativeMission,
+    ]
+]
+
+
+class MissionDefinitionMir(MissionDefinition):
+    """Mission definition that supports MiR-specific step types."""
+
+    steps: MirStepsList  # type: ignore[assignment]
+
+
+class MirInOrbitMission(Mission):
+    """Mission subclass using MiR-specific definition after translation."""
+
+    definition: MissionDefinitionMir  # type: ignore[assignment]

--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -11,6 +11,8 @@
 #     emitted raw math.degrees(theta); MiR's move_to_position rejects orientation outside
 #     [-180, 180] with HTTP 400 (input_number_out_of_range) and InOrbit theta is an
 #     unbounded radian angle (e.g. 6.35 rad -> 364deg).
+#   - 2026-06-27: renamed local n -> n_pending_actions in flush_actions
+#   - 2026-06-27: waypoint_count via sum(map(...)) instead of a generator expression
 
 """Mission translator that compiles consecutive InOrbit waypoint and
 nestable action steps into single native MiR missions.
@@ -101,19 +103,19 @@ class InOrbitToMirTranslator:
         def flush_actions():
             if not pending_actions:
                 return
-            n = len(pending_actions)
-            waypoint_count = sum(1 for a in pending_actions if isinstance(a, MirWaypoint))
-            if waypoint_count == n:
+            n_pending_actions = len(pending_actions)
+            waypoint_count = sum(map(lambda a: isinstance(a, MirWaypoint), pending_actions))
+            if waypoint_count == n_pending_actions:
                 # All waypoints
                 label = (
                     (pending_labels[0] if pending_labels[0] else "Navigate to waypoint")
-                    if n == 1
-                    else f"Navigate {n} waypoints"
+                    if n_pending_actions == 1
+                    else f"Navigate {n_pending_actions} waypoints"
                 )
-            elif n == 1:
+            elif n_pending_actions == 1:
                 label = pending_labels[0] if pending_labels[0] else pending_actions[0].label or ""
             else:
-                label = f"Execute {n} actions"
+                label = f"Execute {n_pending_actions} actions"
             translated_steps.append(
                 MissionStepExecuteMirNativeMission(
                     label=label,

--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/mir_connector/src/mission/translator.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - none (verbatim; intra-package imports are relative, e.g. ``from .datatypes import ...``)
+
+"""Mission translator that compiles consecutive InOrbit waypoint and
+nestable action steps into single native MiR missions.
+
+Step grouping:
+    Input:  [wp_A, wp_B, wait_5s, wp_C, wp_D]
+    Output: [MirNativeMission([A, B, wait, C, D])]
+
+Nestable actions (docking, charging, wait, etc.) are compiled into the
+same native mission alongside waypoints. Non-nestable steps flush the
+current group and pass through to cloud-side execution.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Union
+
+from inorbit_edge_executor.datatypes import (
+    MissionStepPoseWaypoint,
+    MissionStepRunAction,
+    MissionStepWait,
+)
+from inorbit_edge_executor.mission import Mission
+
+from .datatypes import (
+    MirAction,
+    MirInOrbitMission,
+    MirStepsList,
+    MirWaypoint,
+    MissionDefinitionMir,
+    MissionStepExecuteMirNativeMission,
+)
+
+logger = logging.getLogger(__name__)
+
+# MiR action types that can be nested into a compiled native mission.
+NESTABLE_MIR_ACTIONS: set[str] = {
+    "docking",
+    "charging",
+    "wait",
+    "relative_move",
+    "adjust_localization",
+    "set_plc_register",
+    "wait_for_plc_register",
+    "sound",
+    "sound_stop",
+    "light",
+    "pickup_cart",
+    "place_cart",
+    "set_footprint",
+}
+
+
+def _seconds_to_mir_duration(seconds: float) -> str:
+    """Convert seconds to MiR duration string ``HH:MM:SS.ffffff``."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = seconds % 60
+    return f"{h:02d}:{m:02d}:{s:09.6f}"
+
+
+class InOrbitToMirTranslator:
+    """Translates InOrbit missions by compiling consecutive waypoint and
+    nestable action steps into native MiR missions.
+
+    Non-nestable steps flush the current group and pass through unchanged.
+    """
+
+    @staticmethod
+    def translate(
+        mission: Mission,
+    ) -> MirInOrbitMission:
+        """Translate an InOrbit mission to MiR format.
+
+        Consecutive waypoint and nestable action steps are grouped into a
+        single ``MissionStepExecuteMirNativeMission``. Non-nestable steps
+        flush the current group and pass through.
+        """
+        if not mission.definition.steps:
+            raise ValueError("Mission has no steps to translate")
+
+        translated_steps: MirStepsList = []
+        pending_actions: list[Union[MirWaypoint, MirAction]] = []
+        pending_labels: list[str] = []
+
+        def flush_actions():
+            if not pending_actions:
+                return
+            n = len(pending_actions)
+            waypoint_count = sum(1 for a in pending_actions if isinstance(a, MirWaypoint))
+            if waypoint_count == n:
+                # All waypoints
+                label = (
+                    (pending_labels[0] if pending_labels[0] else "Navigate to waypoint")
+                    if n == 1
+                    else f"Navigate {n} waypoints"
+                )
+            elif n == 1:
+                label = pending_labels[0] if pending_labels[0] else pending_actions[0].label or ""
+            else:
+                label = f"Execute {n} actions"
+            translated_steps.append(
+                MissionStepExecuteMirNativeMission(
+                    label=label,
+                    actions=list(pending_actions),
+                    robot_id=mission.robot_id,
+                )
+            )
+            pending_actions.clear()
+            pending_labels.clear()
+
+        for step in mission.definition.steps:
+            if isinstance(step, MissionStepPoseWaypoint):
+                wp = step.waypoint
+                x, y, theta = wp.x, wp.y, wp.theta
+
+                # MiR expects orientation in degrees
+                orientation_deg = math.degrees(theta)
+
+                pending_actions.append(
+                    MirWaypoint(label=step.label, x=x, y=y, orientation=orientation_deg)
+                )
+                pending_labels.append(step.label or "")
+                continue
+
+            if isinstance(step, MissionStepWait):
+                pending_actions.append(
+                    MirAction(
+                        label=step.label,
+                        action_type="wait",
+                        parameters={"time": _seconds_to_mir_duration(step.timeout_secs or 0)},
+                    )
+                )
+                pending_labels.append(step.label or "")
+                continue
+
+            if isinstance(step, MissionStepRunAction) and step.action_id in NESTABLE_MIR_ACTIONS:
+                pending_actions.append(
+                    MirAction(
+                        label=step.label,
+                        action_type=step.action_id,
+                        parameters=step.arguments or {},
+                    )
+                )
+                pending_labels.append(step.label or "")
+                continue
+
+            # Non-nestable step — flush pending actions first
+            flush_actions()
+            translated_steps.append(step)
+
+        flush_actions()
+
+        translated_definition = MissionDefinitionMir(
+            label=mission.definition.label,
+            steps=translated_steps,
+        )
+
+        translated_mission = MirInOrbitMission(
+            id=mission.id,
+            robot_id=mission.robot_id,
+            definition=translated_definition,
+            arguments=mission.arguments,
+        )
+
+        logger.debug(
+            "Translated mission %s: %d original steps -> %d translated steps",
+            mission.id,
+            len(mission.definition.steps),
+            len(translated_steps),
+        )
+
+        return translated_mission

--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -7,7 +7,10 @@
 # Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
 #
 # Modifications from upstream:
-#   - none (verbatim; intra-package imports are relative, e.g. ``from .datatypes import ...``)
+#   - 2026-06-26: normalize waypoint orientation into MiR's [-180, 180] range. Upstream
+#     emitted raw math.degrees(theta); MiR's move_to_position rejects orientation outside
+#     [-180, 180] with HTTP 400 (input_number_out_of_range) and InOrbit theta is an
+#     unbounded radian angle (e.g. 6.35 rad -> 364deg).
 
 """Mission translator that compiles consecutive InOrbit waypoint and
 nestable action steps into single native MiR missions.
@@ -126,8 +129,11 @@ class InOrbitToMirTranslator:
                 wp = step.waypoint
                 x, y, theta = wp.x, wp.y, wp.theta
 
-                # MiR expects orientation in degrees
-                orientation_deg = math.degrees(theta)
+                # MiR expects orientation in degrees, wrapped to [-180, 180]:
+                # move_to_position rejects anything outside that range with HTTP 400
+                # (input_number_out_of_range). InOrbit theta is an unbounded radian
+                # angle, so normalize after converting.
+                orientation_deg = (math.degrees(theta) + 180) % 360 - 180
 
                 pending_actions.append(
                     MirWaypoint(label=step.label, x=x, y=y, orientation=orientation_deg)

--- a/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/mir_connector/src/mission/tree_builder.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - 2026-06-26: rebased intra-package import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+
+"""Tree builder for MiR missions with compiled native mission steps."""
+
+from __future__ import annotations
+
+import logging
+
+from inorbit_edge_executor.behavior_tree import (
+    BehaviorTree,
+    BehaviorTreeErrorHandler,
+    BehaviorTreeSequential,
+    DefaultTreeBuilder,
+    MissionCompletedNode,
+    MissionInProgressNode,
+    MissionPausedNode,
+    register_accepted_node_types,
+)
+from inorbit_edge_executor.inorbit import MissionStatus
+from inorbit_mir_connector.src.mission.behavior_tree import (
+    MirBehaviorTreeBuilderContext,
+    MirMissionAbortedNode,
+    MirNodeFromStepBuilder,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LoggingMissionCompletedNode(MissionCompletedNode):
+    """MissionCompletedNode with debug logging around mt.completed()."""
+
+    async def _execute(self):
+        logger.info(f"MissionCompletedNode: calling mt.completed() for mission {self.mt.id}")
+        try:
+            result = await self.mt.completed()
+            logger.info(f"MissionCompletedNode: mt.completed() returned {result}")
+        except Exception as e:
+            logger.error(f"MissionCompletedNode: mt.completed() raised {e}")
+            raise
+
+
+register_accepted_node_types([LoggingMissionCompletedNode])
+
+
+class MirTreeBuilder(DefaultTreeBuilder):
+    """Tree builder specialized for MiR missions with compiled native steps."""
+
+    def __init__(self, **kwargs):
+        super().__init__(step_builder_factory=MirNodeFromStepBuilder, **kwargs)
+
+    def build_tree_for_mission(self, context: MirBehaviorTreeBuilderContext) -> BehaviorTree:
+        mission = context.mission
+        tree = BehaviorTreeSequential(label=f"mission {mission.id}")
+
+        tree.add_node(MissionInProgressNode(context, label="mission start"))
+
+        step_builder = MirNodeFromStepBuilder(context)
+
+        for ix, step in enumerate(mission.definition.steps):
+            try:
+                node = step.accept(step_builder)
+            except Exception as e:
+                raise RuntimeError(f"Error building step #{ix} [{step}]: {e}") from e
+            if node:
+                tree.add_node(node)
+
+        tree.add_node(LoggingMissionCompletedNode(context, label="mission completed"))
+
+        # Error handling
+        on_error = BehaviorTreeSequential(label="error handlers")
+        on_error.add_node(
+            MirMissionAbortedNode(context, status=MissionStatus.error, label="mission aborted")
+        )
+
+        on_cancel = BehaviorTreeSequential(label="cancel handlers")
+        on_cancel.add_node(
+            MirMissionAbortedNode(context, status=MissionStatus.ok, label="mission cancelled")
+        )
+
+        on_pause = BehaviorTreeSequential(label="pause handlers")
+        # No CleanupMirMissionNode here — MiR mission stays queued.
+        # MirWorkerPool.pause_mission() sets robot state to PAUSE, which
+        # suspends the active MiR mission in place. On resume, set_state(READY)
+        # lets the MiR mission continue from where it was.
+        on_pause.add_node(MissionPausedNode(context, label="mission paused"))
+
+        tree = BehaviorTreeErrorHandler(
+            context,
+            tree,
+            on_error,
+            on_cancel,
+            on_pause,
+            context.error_context,
+            label=f"mission {mission.id}",
+        )
+
+        return tree

--- a/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
@@ -7,7 +7,7 @@
 # Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
 #
 # Modifications from upstream:
-#   - 2026-06-26: rebased intra-package import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+#   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
 
 """Tree builder for MiR missions with compiled native mission steps."""
 

--- a/mir_connector/inorbit_mir_connector/src/mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_exec.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import json
 from enum import Enum
+from typing import Optional
 
 from inorbit_connector.commands import CommandResultCode
 from inorbit_edge_executor.datatypes import MissionRuntimeOptions
@@ -13,12 +14,17 @@ from inorbit_edge_executor.worker_pool import WorkerPool
 from inorbit_edge_executor.db import get_db
 from .mir_api import MirApiV2
 from .mir_api import SetStateId
+from .mir_api.missions_group import MirMissionsGroupHandler
+from .mission.behavior_tree import MirBehaviorTreeBuilderContext
+from .mission.datatypes import MirInOrbitMission
+from .mission.translator import InOrbitToMirTranslator
+from .mission.tree_builder import MirTreeBuilder
 
 # Edge-mission execution module for MiR robots. It extends the inorbit-edge-executor module for
-# translating missions into MiR language and executing them.
-# TODO(b-Tomas): Impleemnt proper translation from InOrbit mission definitions into multi-step
-# MiR missions.
-#   - So far, this implements native pause/resume/abort methods for MiR missions.
+# translating InOrbit missions into native multi-step MiR missions and executing them, with
+# native pause/resume/abort. Translation is wired via the vendored mission module
+# (src/mission/): MirTreeBuilder compiles each mission into a behavior tree whose
+# waypoint/nestable-action runs become native MiR missions.
 
 
 class MissionScriptName(Enum):
@@ -31,10 +37,50 @@ class MissionScriptName(Enum):
 
 class MirWorkerPool(WorkerPool):
 
-    def __init__(self, mir_api: MirApiV2, *args, **kwargs):
+    def __init__(
+        self,
+        mir_api: MirApiV2,
+        *args,
+        missions_group: Optional[MirMissionsGroupHandler] = None,
+        firmware_version: str = "v3",
+        connector_type: str = "",
+        **kwargs,
+    ):
         self.mir_api = mir_api
-        super().__init__(*args, **kwargs)
+        self._missions_group = missions_group
+        self._firmware_version = firmware_version
+        self._connector_type = connector_type
+        super().__init__(*args, behavior_tree_builder=MirTreeBuilder(), **kwargs)
         self.logger = logging.getLogger(name=self.__class__.__name__)
+
+    # @override
+    def create_builder_context(self) -> MirBehaviorTreeBuilderContext:
+        """Build the MiR-aware context the tree builder needs.
+
+        Carries the MiR API plus the temporary missions-group id, firmware
+        version, and connector type. ``submit_work`` fills in mission,
+        options, and shared memory afterwards via ``prepare_builder_context``.
+        """
+        missions_group_id = None
+        if self._missions_group is not None:
+            missions_group_id = self._missions_group.missions_group_id
+        return MirBehaviorTreeBuilderContext(
+            mir_api=self.mir_api,
+            missions_group_id=missions_group_id,
+            firmware_version=self._firmware_version,
+            connector_type=self._connector_type,
+        )
+
+    # @override
+    def translate_mission(self, mission: Mission) -> MirInOrbitMission:
+        """Compile an InOrbit mission into a native-MiR mission definition."""
+        self.logger.debug(f"Translating mission {mission.id}")
+        return InOrbitToMirTranslator.translate(mission=mission)
+
+    # @override
+    def deserialize_mission(self, serialized_mission: dict) -> MirInOrbitMission:
+        """Rehydrate a persisted mission (e.g. on resume) as a MiR mission."""
+        return MirInOrbitMission.model_validate(serialized_mission)
 
     # @override
     async def pause_mission(self, mission_id):
@@ -76,7 +122,16 @@ class MirMissionExecutor:
     Handles mission submission, pause, resume, and abort operations.
     """
 
-    def __init__(self, robot_id, inorbit_api, mir_api, database_file=None):
+    def __init__(
+        self,
+        robot_id,
+        inorbit_api,
+        mir_api,
+        database_file=None,
+        missions_group: Optional[MirMissionsGroupHandler] = None,
+        firmware_version: str = "v3",
+        connector_type: str = "",
+    ):
         """
         Initialize the mission executor.
 
@@ -85,11 +140,18 @@ class MirMissionExecutor:
             inorbit_api: InOrbit API client instance
             mir_api: MIR robot API client instance
             database_file: Optional path to SQLite database file for mission storage
+            missions_group: Handler owning the temporary MiR missions group native
+                missions are created in (None disables native translation's group).
+            firmware_version: MiR firmware ("v2"/"v3"); selects move-action params.
+            connector_type: InOrbit connector type identity, carried on the context.
         """
         self.logger = logging.getLogger(name=self.__class__.__name__)
         self.robot_id = robot_id
         self.inorbit_api = inorbit_api
         self.mir_api = mir_api
+        self._missions_group = missions_group
+        self._firmware_version = firmware_version
+        self._connector_type = connector_type
         # Format database filename for inorbit-edge-executor
         # (expects "sqlite:<filename>" or "dummy")
         if database_file:
@@ -111,6 +173,9 @@ class MirMissionExecutor:
                 mir_api=self.mir_api,
                 api=self.inorbit_api,
                 db=db,
+                missions_group=self._missions_group,
+                firmware_version=self._firmware_version,
+                connector_type=self._connector_type,
             )
             await self._worker_pool.start()
             self._initialized = True

--- a/mir_connector/inorbit_mir_connector/tests/test_behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_behavior_tree.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/tests/test_behavior_tree.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+
+"""Unit tests for MiR behavior tree node serialization (dump/from_object)."""
+
+from __future__ import annotations
+
+import pytest
+
+from inorbit_mir_connector.src.mission.datatypes import (
+    MirAction,
+    MirWaypoint,
+    MissionStepExecuteMirNativeMission,
+)
+
+
+class TestMissionStepExecuteMirNativeMissionSerialization:
+    """Verify round-trip serialization of MissionStepExecuteMirNativeMission.
+
+    This is critical for pause/resume: the step is serialized to SQLite
+    on pause and deserialized on resume via model_validate().
+    """
+
+    def _make_step_with_waypoints(self):
+        return MissionStepExecuteMirNativeMission(
+            label="Navigate 2 waypoints",
+            actions=[
+                MirWaypoint(label="wp1", x=1.0, y=2.0, orientation=90.0),
+                MirWaypoint(label="wp2", x=3.0, y=4.0, orientation=180.0),
+            ],
+            robot_id="mir200-1",
+        )
+
+    def _make_step_with_actions(self):
+        return MissionStepExecuteMirNativeMission(
+            label="Execute 2 actions",
+            actions=[
+                MirAction(label="Wait", action_type="wait", parameters={"time": "00:01:00.000000"}),
+                MirWaypoint(label="wp1", x=1.0, y=2.0, orientation=90.0),
+            ],
+            robot_id="mir200-1",
+        )
+
+    def _make_step_wait_only(self):
+        return MissionStepExecuteMirNativeMission(
+            label="Wait only",
+            actions=[
+                MirAction(
+                    label="Wait 60 seconds",
+                    action_type="wait",
+                    parameters={"time": "00:01:00.000000"},
+                ),
+            ],
+            robot_id="mir200-1",
+        )
+
+    def test_round_trip_waypoints(self):
+        step = self._make_step_with_waypoints()
+        serialized = step.model_dump(mode="json", exclude_none=True)
+        restored = MissionStepExecuteMirNativeMission.model_validate(serialized)
+        assert len(restored.actions) == 2
+        assert isinstance(restored.actions[0], MirWaypoint)
+        assert restored.actions[0].x == 1.0
+        assert restored.actions[1].orientation == 180.0
+
+    def test_round_trip_mixed_actions(self):
+        step = self._make_step_with_actions()
+        serialized = step.model_dump(mode="json", exclude_none=True)
+        restored = MissionStepExecuteMirNativeMission.model_validate(serialized)
+        assert len(restored.actions) == 2
+        assert isinstance(restored.actions[0], MirAction)
+        assert restored.actions[0].action_type == "wait"
+        assert isinstance(restored.actions[1], MirWaypoint)
+
+    def test_round_trip_wait_only(self):
+        """Reproduces the v0.1.19 bug: wait-only step failed to deserialize."""
+        step = self._make_step_wait_only()
+        serialized = step.model_dump(mode="json", exclude_none=True)
+        restored = MissionStepExecuteMirNativeMission.model_validate(serialized)
+        assert len(restored.actions) == 1
+        assert isinstance(restored.actions[0], MirAction)
+        assert restored.actions[0].action_type == "wait"
+
+    def test_round_trip_fails_without_exclude_none(self):
+        """Confirms the bug: model_dump without exclude_none produces invalid data."""
+        step = self._make_step_wait_only()
+        serialized = step.model_dump(mode="json")  # no exclude_none
+        with pytest.raises(Exception):
+            MissionStepExecuteMirNativeMission.model_validate(serialized)

--- a/mir_connector/inorbit_mir_connector/tests/test_marker_type.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_marker_type.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/tests/test_marker_type.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+#     (resolve_marker_type / DockingOffsetError live in our mir_api package)
+
+"""Unit tests for docking marker_type auto-resolution (resolve_marker_type)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from inorbit_mir_connector.src.mir_api import DockingOffsetError, resolve_marker_type
+
+_LOG = logging.getLogger("test")
+
+_MARKER = "00000000-0000-0000-0000-00000000aaaa"
+_OFFSET = "00000000-0000-0000-0000-00000000bbbb"
+
+
+class _FakeMirApi:
+    """Minimal stub exposing get_position_docking_offsets."""
+
+    def __init__(self, offsets=None, raises=None):
+        self._offsets = offsets if offsets is not None else []
+        self._raises = raises
+        self.calls: list[str] = []
+
+    async def get_position_docking_offsets(self, position_guid: str) -> list:
+        self.calls.append(position_guid)
+        if self._raises is not None:
+            raise self._raises
+        return self._offsets
+
+
+@pytest.mark.asyncio
+async def test_resolves_marker_type_when_offset_exists():
+    api = _FakeMirApi(offsets=[{"guid": _OFFSET}])
+    result = await resolve_marker_type(api, "docking", {"marker": _MARKER}, _LOG)
+    assert result == {"marker": _MARKER, "marker_type": _OFFSET}
+    assert api.calls == [_MARKER]
+
+
+@pytest.mark.asyncio
+async def test_raises_when_no_offset():
+    api = _FakeMirApi(offsets=[])
+    with pytest.raises(DockingOffsetError, match="no docking offset"):
+        await resolve_marker_type(api, "docking", {"marker": _MARKER}, _LOG)
+
+
+@pytest.mark.asyncio
+async def test_empty_marker_type_is_resolved():
+    api = _FakeMirApi(offsets=[{"guid": _OFFSET}])
+    result = await resolve_marker_type(api, "docking", {"marker": _MARKER, "marker_type": ""}, _LOG)
+    assert result["marker_type"] == _OFFSET
+
+
+@pytest.mark.asyncio
+async def test_explicit_marker_type_passes_through():
+    api = _FakeMirApi(offsets=[{"guid": _OFFSET}])
+    params = {"marker": _MARKER, "marker_type": "explicit-guid"}
+    result = await resolve_marker_type(api, "docking", params, _LOG)
+    assert result == params
+    assert api.calls == []  # already set — no lookup
+
+
+@pytest.mark.asyncio
+async def test_raises_when_lookup_fails():
+    api = _FakeMirApi(raises=RuntimeError("TCP reset"))
+    with pytest.raises(DockingOffsetError, match="could not look up"):
+        await resolve_marker_type(api, "docking", {"marker": _MARKER}, _LOG)
+
+
+@pytest.mark.asyncio
+async def test_raises_when_offset_response_malformed():
+    api = _FakeMirApi(offsets=[{"no_guid_field": 1}])
+    with pytest.raises(DockingOffsetError):
+        await resolve_marker_type(api, "docking", {"marker": _MARKER}, _LOG)
+
+
+@pytest.mark.asyncio
+async def test_non_docking_action_passes_through():
+    api = _FakeMirApi(offsets=[{"guid": _OFFSET}])
+    params = {"minimum_percentage": 95.0}
+    result = await resolve_marker_type(api, "charging", params, _LOG)
+    assert result == params
+    assert api.calls == []
+
+
+@pytest.mark.asyncio
+async def test_docking_without_marker_passes_through():
+    api = _FakeMirApi(offsets=[{"guid": _OFFSET}])
+    params = {"retries": 10}
+    result = await resolve_marker_type(api, "docking", params, _LOG)
+    assert result == params
+    assert api.calls == []

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -71,6 +71,30 @@ async def test_get_executing_mission_id(mir_api, httpx_mock):
 
 
 @pytest.mark.asyncio
+async def test_abort_all_missions(mir_api, httpx_mock):
+    httpx_mock.add_response(
+        method="DELETE", url=f"{mir_api.mir_api_base_url}/mission_queue", status_code=204
+    )
+    await mir_api.abort_all_missions()
+    request = httpx_mock.get_request(method="DELETE")
+    assert request is not None
+    assert str(request.url) == f"{mir_api.mir_api_base_url}/mission_queue"
+
+
+@pytest.mark.asyncio
+async def test_abort_mission(mir_api, httpx_mock):
+    """abort_mission scopes the abort to a single queue entry via DELETE
+    /mission_queue/{id}, leaving the rest of the queue intact."""
+    httpx_mock.add_response(
+        method="DELETE", url=f"{mir_api.mir_api_base_url}/mission_queue/42", status_code=204
+    )
+    await mir_api.abort_mission(42)
+    request = httpx_mock.get_request(method="DELETE")
+    assert request is not None
+    assert str(request.url) == f"{mir_api.mir_api_base_url}/mission_queue/42"
+
+
+@pytest.mark.asyncio
 async def test_get_metrics(mir_api, httpx_mock):
     input = """
 # HELP mir_robot_localization_score A measure of the robots position estimate relative to the map. A value of 0 indicates a perfect value and values closer to zero are better.

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging
+
 import pytest
 from inorbit_mir_connector.src.mir_api import MirApiV2
 from deepdiff import DeepDiff
@@ -29,6 +31,30 @@ async def test_http_error(mir_api, httpx_mock):
     )
     with pytest.raises(httpx.HTTPStatusError):
         await mir_api.get_metrics()
+
+
+@pytest.mark.asyncio
+async def test_http_error_logs_response_body(mir_api, httpx_mock, caplog):
+    """A failed MiR request must log the response body.
+
+    ``raise_for_status()`` produces an ``HTTPStatusError`` whose ``str()`` only
+    carries the status line ("Client error '400 Bad Request' ...") — the body
+    MiR returns explaining *why* it rejected the request (e.g. a bad mission
+    action parameter) is otherwise lost. Native-mission creation surfaces that
+    error as its abort reason, so the body must reach the logs.
+    """
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{mir_api.mir_api_base_url}/missions",
+        status_code=400,
+        json={"error": {"message": "action parameter 'time' is invalid"}},
+    )
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(httpx.HTTPStatusError):
+            await mir_api.create_mission(group_id="group-guid", name="m")
+
+    assert "400" in caplog.text
+    assert "action parameter 'time' is invalid" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Execution tests for CreateMirNativeMissionNode.
+
+Unlike the vendored ``test_behavior_tree.py`` (which only covers step
+serialization), this exercises the node's ``_execute`` against a mocked
+``MirApiV2``: it must create a native MiR mission in the missions group, add
+one action per entry (resolving docking markers), queue it, and record the
+mission/queue ids in shared memory. Written here (not vendored) because the
+upstream module ships no execution test for this node.
+"""
+
+from __future__ import annotations
+
+import pytest
+from inorbit_edge_executor.datatypes import MissionRuntimeSharedMemory
+
+from inorbit_mir_connector.src.mission.behavior_tree import (
+    CreateMirNativeMissionNode,
+    MirBehaviorTreeBuilderContext,
+    SharedMemoryKeys,
+)
+from inorbit_mir_connector.src.mission.datatypes import (
+    MirAction,
+    MirWaypoint,
+    MissionStepExecuteMirNativeMission,
+)
+
+_MARKER = "00000000-0000-0000-0000-00000000aaaa"
+_OFFSET = "00000000-0000-0000-0000-00000000bbbb"
+
+
+class FakeMirApi:
+    """Records the native-mission calls CreateMirNativeMissionNode makes."""
+
+    def __init__(self, offsets_by_marker=None, queue_id=42):
+        self.created: list[dict] = []
+        self.actions: list[dict] = []
+        self.queued: list[str] = []
+        self._offsets_by_marker = offsets_by_marker or {}
+        self._queue_id = queue_id
+
+    async def create_mission(self, group_id, name, guid, description):
+        self.created.append(
+            {"group_id": group_id, "name": name, "guid": guid, "description": description}
+        )
+
+    async def add_action_to_mission(self, action_type, mission_id, parameters, priority):
+        self.actions.append(
+            {
+                "action_type": action_type,
+                "mission_id": mission_id,
+                "parameters": parameters,
+                "priority": priority,
+            }
+        )
+
+    async def queue_mission(self, mission_guid):
+        self.queued.append(mission_guid)
+        return {"id": self._queue_id}
+
+    async def get_position_docking_offsets(self, position_guid):
+        return self._offsets_by_marker.get(position_guid, [])
+
+
+def _build_node(api, actions, missions_group_id="grp-1", firmware_version="v3"):
+    """Build a CreateMirNativeMissionNode and its (frozen) context.
+
+    Mirrors the real submit_work flow: the node's __init__ registers shared
+    memory keys via add(), then the memory is frozen before _execute() runs
+    (set() requires a frozen memory).
+    """
+    ctx = MirBehaviorTreeBuilderContext(
+        mir_api=api,
+        missions_group_id=missions_group_id,
+        firmware_version=firmware_version,
+        connector_type="mir",
+    )
+    ctx.shared_memory = MissionRuntimeSharedMemory()
+    step = MissionStepExecuteMirNativeMission(
+        label="Native mission", actions=actions, robot_id="mir-1"
+    )
+    node = CreateMirNativeMissionNode(ctx, step)
+    ctx.shared_memory.freeze()
+    return node, ctx
+
+
+def _action_param_ids(action):
+    """Set of MiR parameter ``id``s recorded for an add_action_to_mission call."""
+    return {p["id"] for p in action["parameters"]}
+
+
+@pytest.mark.asyncio
+async def test_creates_adds_actions_and_queues():
+    api = FakeMirApi(queue_id=99)
+    node, ctx = _build_node(
+        api,
+        [
+            MirWaypoint(label="wp1", x=1.0, y=2.0, orientation=90.0),
+            MirWaypoint(label="wp2", x=3.0, y=4.0, orientation=180.0),
+            MirAction(label="Wait", action_type="wait", parameters={"time": "00:00:05.000000"}),
+        ],
+    )
+
+    await node._execute()
+
+    # One mission created in the configured group.
+    assert len(api.created) == 1
+    assert api.created[0]["group_id"] == "grp-1"
+    mission_guid = api.created[0]["guid"]
+
+    # One action per entry, in order, priorities 1..N.
+    assert [a["action_type"] for a in api.actions] == [
+        "move_to_position",
+        "move_to_position",
+        "wait",
+    ]
+    assert [a["priority"] for a in api.actions] == [1, 2, 3]
+    assert all(a["mission_id"] == mission_guid for a in api.actions)
+
+    # Queued once, ids stashed in shared memory.
+    assert api.queued == [mission_guid]
+    assert ctx.shared_memory.get(SharedMemoryKeys.MIR_MISSION_GUID) == mission_guid
+    assert ctx.shared_memory.get(SharedMemoryKeys.MIR_QUEUE_ID) == 99
+
+
+@pytest.mark.asyncio
+async def test_waypoint_params_v3_use_blocked_path_timeout():
+    api = FakeMirApi()
+    node, _ = _build_node(
+        api, [MirWaypoint(label="wp", x=1, y=2, orientation=0)], firmware_version="v3"
+    )
+
+    await node._execute()
+
+    ids = _action_param_ids(api.actions[0])
+    assert "blocked_path_timeout" in ids
+    assert "retries" not in ids
+
+
+@pytest.mark.asyncio
+async def test_waypoint_params_v2_use_retries():
+    api = FakeMirApi()
+    node, _ = _build_node(
+        api, [MirWaypoint(label="wp", x=1, y=2, orientation=0)], firmware_version="v2"
+    )
+
+    await node._execute()
+
+    ids = _action_param_ids(api.actions[0])
+    assert "retries" in ids
+    assert "blocked_path_timeout" not in ids
+
+
+@pytest.mark.asyncio
+async def test_missing_missions_group_raises():
+    api = FakeMirApi()
+    node, ctx = _build_node(
+        api, [MirWaypoint(label="wp", x=1, y=2, orientation=0)], missions_group_id=None
+    )
+
+    with pytest.raises(RuntimeError):
+        await node._execute()
+
+    assert api.created == []
+    assert ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_docking_marker_type_resolved():
+    api = FakeMirApi(offsets_by_marker={_MARKER: [{"guid": _OFFSET}]})
+    node, ctx = _build_node(
+        api, [MirAction(label="Dock", action_type="docking", parameters={"marker": _MARKER})]
+    )
+
+    await node._execute()
+
+    params = {p["id"]: p["value"] for p in api.actions[0]["parameters"]}
+    assert params["marker_type"] == _OFFSET
+    assert api.queued == [api.created[0]["guid"]]
+
+
+@pytest.mark.asyncio
+async def test_docking_without_offset_raises_and_does_not_queue():
+    api = FakeMirApi(offsets_by_marker={})  # no offset for the marker
+    node, ctx = _build_node(
+        api, [MirAction(label="Dock", action_type="docking", parameters={"marker": _MARKER})]
+    )
+
+    with pytest.raises(RuntimeError):
+        await node._execute()
+
+    assert api.queued == []
+    assert ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
@@ -14,12 +14,16 @@ upstream module ships no execution test for this node.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 from inorbit_edge_executor.datatypes import MissionRuntimeSharedMemory
 
 from inorbit_mir_connector.src.mission.behavior_tree import (
+    CleanupMirMissionNode,
     CreateMirNativeMissionNode,
     MirBehaviorTreeBuilderContext,
+    MirMissionAbortedNode,
     SharedMemoryKeys,
 )
 from inorbit_mir_connector.src.mission.datatypes import (
@@ -39,8 +43,16 @@ class FakeMirApi:
         self.created: list[dict] = []
         self.actions: list[dict] = []
         self.queued: list[str] = []
+        self.aborted_entries: list = []
+        self.abort_all_count: int = 0
         self._offsets_by_marker = offsets_by_marker or {}
         self._queue_id = queue_id
+
+    async def abort_mission(self, mission_queue_id):
+        self.aborted_entries.append(mission_queue_id)
+
+    async def abort_all_missions(self):
+        self.abort_all_count += 1
 
     async def create_mission(self, group_id, name, guid, description):
         self.created.append(
@@ -194,3 +206,81 @@ async def test_docking_without_offset_raises_and_does_not_queue():
 
     assert api.queued == []
     assert ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+
+
+def _build_abort_context(api, queue_id):
+    """Context with a frozen shared memory holding (optionally) a queue id.
+
+    Mirrors the shape CreateMirNativeMissionNode leaves behind: the queue/error
+    keys are declared, the memory is frozen, then the queue id is stored. Pass
+    queue_id=None to model an abort before any mission was queued.
+    """
+    ctx = MirBehaviorTreeBuilderContext(
+        mir_api=api,
+        missions_group_id="grp-1",
+        firmware_version="v3",
+        connector_type="mir",
+        mt=AsyncMock(),
+        error_context={"last_error": "boom"},
+    )
+    sm = MissionRuntimeSharedMemory()
+    sm.add(SharedMemoryKeys.MIR_QUEUE_ID, None)
+    sm.add(SharedMemoryKeys.MIR_ERROR_MESSAGE, None)
+    sm.freeze()
+    if queue_id is not None:
+        sm.set(SharedMemoryKeys.MIR_QUEUE_ID, queue_id)
+    ctx.shared_memory = sm
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_abort_node_scopes_abort_to_queue_entry():
+    api = FakeMirApi()
+    ctx = _build_abort_context(api, queue_id=42)
+    node = MirMissionAbortedNode(ctx)
+
+    await node._execute()
+
+    # Only the one queued mission is aborted; the queue is left otherwise intact.
+    assert api.aborted_entries == [42]
+    assert api.abort_all_count == 0
+    # Base MissionAbortedNode still reports the abort to mission tracking.
+    ctx.mt.abort.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_abort_node_without_queue_id_aborts_nothing():
+    api = FakeMirApi()
+    ctx = _build_abort_context(api, queue_id=None)
+    node = MirMissionAbortedNode(ctx)
+
+    await node._execute()
+
+    # No queue id -> no MiR abort call at all (no fallback to abort_all_missions).
+    assert api.aborted_entries == []
+    assert api.abort_all_count == 0
+    ctx.mt.abort.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_node_scopes_abort_to_queue_entry():
+    api = FakeMirApi()
+    ctx = _build_abort_context(api, queue_id=42)
+    node = CleanupMirMissionNode(ctx)
+
+    await node._execute()
+
+    assert api.aborted_entries == [42]
+    assert api.abort_all_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cleanup_node_without_queue_id_is_noop():
+    api = FakeMirApi()
+    ctx = _build_abort_context(api, queue_id=None)
+    node = CleanupMirMissionNode(ctx)
+
+    await node._execute()
+
+    assert api.aborted_entries == []
+    assert api.abort_all_count == 0

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_exec.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Wiring tests for MirWorkerPool (spec §4.5).
+
+Confirms the worker pool routes the SDK mission engine through the vendored
+mission module: native tree builder, translation, context construction, and
+deserialization. The pool is built with sentinel ``api``/``db`` and never
+started — only the synchronous override hooks are exercised.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from inorbit_edge_executor.datatypes import (
+    MissionDefinition,
+    MissionStepPoseWaypoint,
+    Pose,
+)
+from inorbit_edge_executor.mission import Mission
+
+from inorbit_mir_connector.src.mission.behavior_tree import MirBehaviorTreeBuilderContext
+from inorbit_mir_connector.src.mission.datatypes import (
+    MirInOrbitMission,
+    MissionStepExecuteMirNativeMission,
+)
+from inorbit_mir_connector.src.mission.tree_builder import MirTreeBuilder
+from inorbit_mir_connector.src.mission_exec import MirWorkerPool
+
+ROBOT_ID = "mir-1"
+
+
+def _make_pool(missions_group=None, firmware_version="v3", connector_type="mir"):
+    # WorkerPool only requires a truthy ``api``; ``db`` is untouched until start().
+    return MirWorkerPool(
+        mir_api=SimpleNamespace(),
+        api=object(),
+        db=object(),
+        missions_group=missions_group,
+        firmware_version=firmware_version,
+        connector_type=connector_type,
+    )
+
+
+def _waypoint_mission():
+    return Mission(
+        id="mission-001",
+        robot_id=ROBOT_ID,
+        definition=MissionDefinition(
+            label="test",
+            steps=[
+                MissionStepPoseWaypoint(waypoint=Pose(x=1, y=2, theta=0), label="a"),
+                MissionStepPoseWaypoint(waypoint=Pose(x=3, y=4, theta=0), label="b"),
+            ],
+        ),
+    )
+
+
+def test_uses_mir_tree_builder():
+    pool = _make_pool()
+    assert isinstance(pool._behavior_tree_builder, MirTreeBuilder)
+
+
+def test_translate_mission_compiles_to_native():
+    pool = _make_pool()
+    result = pool.translate_mission(_waypoint_mission())
+
+    assert isinstance(result, MirInOrbitMission)
+    assert len(result.definition.steps) == 1
+    assert isinstance(result.definition.steps[0], MissionStepExecuteMirNativeMission)
+
+
+def test_create_builder_context_carries_handles():
+    group = SimpleNamespace(missions_group_id="grp-xyz")
+    mir_api = SimpleNamespace()
+    pool = MirWorkerPool(
+        mir_api=mir_api,
+        api=object(),
+        db=object(),
+        missions_group=group,
+        firmware_version="v2",
+        connector_type="mir",
+    )
+    ctx = pool.create_builder_context()
+
+    assert isinstance(ctx, MirBehaviorTreeBuilderContext)
+    assert ctx.mir_api is mir_api
+    assert ctx.missions_group_id == "grp-xyz"
+    assert ctx.firmware_version == "v2"
+    assert ctx.connector_type == "mir"
+
+
+def test_create_builder_context_without_group():
+    pool = _make_pool(missions_group=None)
+    ctx = pool.create_builder_context()
+    assert ctx.missions_group_id is None
+
+
+def test_deserialize_mission_round_trips():
+    pool = _make_pool()
+    translated = pool.translate_mission(_waypoint_mission())
+    serialized = translated.model_dump(mode="json", exclude_none=True)
+
+    restored = pool.deserialize_mission(serialized)
+
+    assert isinstance(restored, MirInOrbitMission)
+    assert isinstance(restored.definition.steps[0], MissionStepExecuteMirNativeMission)

--- a/mir_connector/inorbit_mir_connector/tests/test_translator.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_translator.py
@@ -8,6 +8,8 @@
 #
 # Modifications from upstream:
 #   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+#   - 2026-06-26: added TestOrientationNormalization (orientation wrapped to MiR's
+#     [-180, 180] range; MiR rejects move_to_position outside it with HTTP 400)
 
 """Unit tests for InOrbitToMirTranslator."""
 
@@ -81,6 +83,30 @@ class TestTranslateWaypointsOnly:
         assert len(step.actions) == 2
         assert all(isinstance(a, MirWaypoint) for a in step.actions)
         assert step.label == "Navigate 2 waypoints"
+
+
+class TestOrientationNormalization:
+    """MiR's move_to_position rejects orientation outside [-180, 180] with a 400
+    (``input_number_out_of_range``). InOrbit waypoint theta is an unbounded angle
+    in radians, so the degrees conversion must wrap into MiR's range."""
+
+    @pytest.mark.parametrize(
+        "theta_rad, expected_deg",
+        [
+            (math.radians(90), 90.0),  # in range, unchanged
+            (math.radians(-90), -90.0),  # in range, unchanged
+            (math.radians(185), -175.0),  # just over +180
+            (math.radians(-185), 175.0),  # just under -180
+            (math.radians(364.1), 4.1),  # full turn + a bit
+            (6.354400934754617, math.degrees(6.354400934754617) - 360),  # real mission theta
+        ],
+    )
+    def test_orientation_wrapped_into_mir_range(self, theta_rad, expected_deg):
+        result = InOrbitToMirTranslator.translate(_mission([_pose_wp(1, 2, theta=theta_rad)]))
+        wp = result.definition.steps[0].actions[0]
+        assert isinstance(wp, MirWaypoint)
+        assert -180 <= wp.orientation <= 180
+        assert wp.orientation == pytest.approx(expected_deg, abs=1e-6)
 
 
 class TestTranslateWaitNested:

--- a/mir_connector/inorbit_mir_connector/tests/test_translator.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_translator.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2026 Mappalink
+#
+# SPDX-License-Identifier: MIT
+#
+# Vendored from the Mappalink MiR connector:
+#   https://github.com/mappalink/inorbit-mir-connector/blob/c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925/tests/test_translator.py
+# Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
+#
+# Modifications from upstream:
+#   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+
+"""Unit tests for InOrbitToMirTranslator."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from inorbit_edge_executor.datatypes import (
+    MissionDefinition,
+    MissionStepPoseWaypoint,
+    MissionStepRunAction,
+    MissionStepSetData,
+    MissionStepWait,
+    Pose,
+)
+from inorbit_edge_executor.mission import Mission
+
+from inorbit_mir_connector.src.mission.datatypes import (
+    MirAction,
+    MirWaypoint,
+    MissionStepExecuteMirNativeMission,
+)
+from inorbit_mir_connector.src.mission.translator import (
+    InOrbitToMirTranslator,
+    _seconds_to_mir_duration,
+)
+
+ROBOT_ID = "test-robot-01"
+
+
+def _pose_wp(x: float, y: float, theta: float = 0.0, label: str = "wp"):
+    """Helper to build a MissionStepPoseWaypoint."""
+    return MissionStepPoseWaypoint(
+        waypoint=Pose(x=x, y=y, theta=theta),
+        label=label,
+    )
+
+
+def _wait(secs: float, label: str = "wait"):
+    return MissionStepWait(timeoutSecs=secs, label=label)
+
+
+def _run_action(action_id: str, arguments: dict | None = None, label: str = "action"):
+    kwargs: dict = {"actionId": action_id}
+    if arguments is not None:
+        kwargs["arguments"] = arguments
+    return MissionStepRunAction(runAction=kwargs, label=label)
+
+
+def _set_data(data: dict, label: str = "data"):
+    return MissionStepSetData(data=data, label=label)
+
+
+def _mission(steps, label: str = "test"):
+    return Mission(
+        id="mission-001",
+        robot_id=ROBOT_ID,
+        definition=MissionDefinition(label=label, steps=steps),
+    )
+
+
+class TestTranslateWaypointsOnly:
+    def test_consecutive_waypoints_compiled(self):
+        m = _mission([_pose_wp(1, 2), _pose_wp(3, 4)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 2
+        assert all(isinstance(a, MirWaypoint) for a in step.actions)
+        assert step.label == "Navigate 2 waypoints"
+
+
+class TestTranslateWaitNested:
+    def test_wait_nested_between_waypoints(self):
+        m = _mission([_pose_wp(1, 2), _wait(5), _pose_wp(3, 4)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        # All three should be in a single compiled mission
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 3
+        assert isinstance(step.actions[0], MirWaypoint)
+        assert isinstance(step.actions[1], MirAction)
+        assert step.actions[1].action_type == "wait"
+        assert step.actions[1].parameters["time"] == "00:00:05.000000"
+        assert isinstance(step.actions[2], MirWaypoint)
+        assert step.label == "Execute 3 actions"
+
+
+class TestTranslateRunActionNestable:
+    def test_nestable_action_compiled(self):
+        m = _mission([_pose_wp(1, 2), _run_action("docking", {"marker": "guid-1"})])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 2
+        assert isinstance(step.actions[1], MirAction)
+        assert step.actions[1].action_type == "docking"
+        assert step.actions[1].parameters == {"marker": "guid-1"}
+
+    def test_set_footprint_nestable(self):
+        m = _mission([_pose_wp(1, 2), _run_action("set_footprint", {"footprint": "guid-fp"})])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 2
+        assert isinstance(step.actions[1], MirAction)
+        assert step.actions[1].action_type == "set_footprint"
+        assert step.actions[1].parameters == {"footprint": "guid-fp"}
+
+
+class TestTranslateRunActionNonNestable:
+    def test_non_nestable_action_flushes(self):
+        m = _mission([_pose_wp(1, 2), _run_action("unknown_action"), _pose_wp(3, 4)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 3
+        assert isinstance(result.definition.steps[0], MissionStepExecuteMirNativeMission)
+        assert isinstance(result.definition.steps[1], MissionStepRunAction)
+        assert isinstance(result.definition.steps[2], MissionStepExecuteMirNativeMission)
+
+
+class TestTranslateSetDataFlushes:
+    def test_set_data_flushes(self):
+        m = _mission([_pose_wp(1, 2), _set_data({"key": "val"}), _pose_wp(3, 4)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 3
+        assert isinstance(result.definition.steps[0], MissionStepExecuteMirNativeMission)
+        assert isinstance(result.definition.steps[1], MissionStepSetData)
+        assert isinstance(result.definition.steps[2], MissionStepExecuteMirNativeMission)
+
+
+class TestTranslateActionsOnly:
+    def test_actions_only_no_waypoints(self):
+        m = _mission([_run_action("docking"), _wait(10), _run_action("charging")])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 3
+        assert all(isinstance(a, MirAction) for a in step.actions)
+        assert step.actions[0].action_type == "docking"
+        assert step.actions[1].action_type == "wait"
+        assert step.actions[2].action_type == "charging"
+
+
+class TestDurationHelper:
+    @pytest.mark.parametrize(
+        "seconds, expected",
+        [
+            (0, "00:00:00.000000"),
+            (65.5, "00:01:05.500000"),
+            (3661.123, "01:01:01.123000"),
+            (0.001, "00:00:00.001000"),
+        ],
+    )
+    def test_seconds_to_mir_duration(self, seconds, expected):
+        assert _seconds_to_mir_duration(seconds) == expected
+
+
+class TestTranslateEmpty:
+    def test_empty_mission_raises(self):
+        m = _mission([])
+        with pytest.raises(ValueError, match="no steps"):
+            InOrbitToMirTranslator.translate(m)
+
+
+class TestWaypointOrientationConversion:
+    def test_theta_converted_to_degrees(self):
+        theta = math.pi / 4  # 45 degrees
+        m = _mission([_pose_wp(1, 2, theta)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        step = result.definition.steps[0]
+        wp = step.actions[0]
+        assert isinstance(wp, MirWaypoint)
+        assert wp.orientation == pytest.approx(45.0)


### PR DESCRIPTION
## Summary

Translates InOrbit missions into native MiR missions instead of executing every step as a cloud `NavigateTo` round-trip. Achieved by vendoring Mappalink's mission-translation module and wiring it into `MirWorkerPool`.

The translator groups consecutive waypoint and nestable-action steps into a native MiR mission (create mission, add one action per step, queue), polls the MiR mission queue for completion, and splits on InOrbit-only steps (`setData`, `waitUntil`, non-nestable actions) so those still run cloud-side between native missions.

Includes:

- Vendored `src/mission/` package (`translator`, `tree_builder`, `behavior_tree`, `datatypes`), kept verbatim from upstream `c516f7d` with provenance and change-log headers plus a `CLAUDE.md` re-sync guide.
- `mir_api` parity: `queue_mission` returns the queue entry, a lightweight `get_mission_queue_entry`, and docking marker-type resolution (`resolve_marker_type`, `DockingOffsetError`, `get_position_docking_offsets`).
- Wiring: `MirWorkerPool` overrides `translate_mission` / `create_builder_context` / `deserialize_mission` and uses `MirTreeBuilder`. Existing pause/resume/cancel behavior preserved.
- Tests for the translator, native-mission node, behavior tree, marker-type resolution, and mission-exec wiring. Suite green.

Depends on the Connect SDK bump already merged in #106.

## Pending (follow-up PRs)

Blocker before production use:

- Abort/cancel handler crashes for a mission with no native step, leaving it in-progress and skipping the queue flush.

Hardening and tests:

- Restore per-task mission tracking (the vendored tree builder drops the task decorator; InOrbit relies on per-task progress).
- Guard the legacy nav / `queue_mission` / `run_mission_now` verbs against an active executor mission.
- Fix the missions-group startup race (await group setup before the pool accepts work).
- Add behavior-preservation tests: pause/resume/cancel contract, completion-poller terminal states, abort state, resume-after-restart.
- Enforce a native-mission timeout (currently unbounded).

Feature follow-ups:

- Wire the "dispatch MiR mission by id" action into the translator; explore mission-in-mission nesting.
- Translate InOrbit actions that MiR can interpret natively.
- Explore mapping `wait_for` / `waitUntil` expressions to robot state (platform side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
