### PR TITLE
MiR connector: restore per-task mission tracking for edge missions

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -13,6 +13,12 @@
 #     unbounded radian angle (e.g. 6.35 rad -> 364deg).
 #   - 2026-06-27: renamed local n -> n_pending_actions in flush_actions
 #   - 2026-06-27: waypoint_count via sum(map(...)) instead of a generator expression
+#   - 2026-06-27: preserve InOrbit per-task tracking (spec §11.1). A grouped (nestable) step
+#     carrying complete_task now flushes the current native group and stamps complete_task onto
+#     the emitted MissionStepExecuteMirNativeMission, so the task is reported (it lands in
+#     Mission.tasks_list and the tree builder's decorator emits TaskStarted/TaskCompletedNode).
+#     Non-nestable steps already pass through verbatim and keep their complete_task. Grouping is
+#     unchanged for missions whose steps carry no complete_task.
 
 """Mission translator that compiles consecutive InOrbit waypoint and
 nestable action steps into single native MiR missions.
@@ -99,9 +105,13 @@ class InOrbitToMirTranslator:
         translated_steps: MirStepsList = []
         pending_actions: list[Union[MirWaypoint, MirAction]] = []
         pending_labels: list[str] = []
+        # complete_task to stamp onto the next flushed native group, so InOrbit per-task
+        # tracking survives the grouping (set when a grouped step carries complete_task).
+        pending_complete_task: list[Union[str, None]] = [None]
 
         def flush_actions():
             if not pending_actions:
+                pending_complete_task[0] = None
                 return
             n_pending_actions = len(pending_actions)
             waypoint_count = sum(map(lambda a: isinstance(a, MirWaypoint), pending_actions))
@@ -116,15 +126,19 @@ class InOrbitToMirTranslator:
                 label = pending_labels[0] if pending_labels[0] else pending_actions[0].label or ""
             else:
                 label = f"Execute {n_pending_actions} actions"
-            translated_steps.append(
-                MissionStepExecuteMirNativeMission(
-                    label=label,
-                    actions=list(pending_actions),
-                    robot_id=mission.robot_id,
-                )
-            )
+            native_kwargs: dict = {
+                "label": label,
+                "actions": list(pending_actions),
+                "robot_id": mission.robot_id,
+            }
+            # Only set completeTask when present: the field is typed ``str`` (default None),
+            # so passing None explicitly fails validation.
+            if pending_complete_task[0] is not None:
+                native_kwargs["completeTask"] = pending_complete_task[0]
+            translated_steps.append(MissionStepExecuteMirNativeMission(**native_kwargs))
             pending_actions.clear()
             pending_labels.clear()
+            pending_complete_task[0] = None
 
         for step in mission.definition.steps:
             if isinstance(step, MissionStepPoseWaypoint):
@@ -141,6 +155,9 @@ class InOrbitToMirTranslator:
                     MirWaypoint(label=step.label, x=x, y=y, orientation=orientation_deg)
                 )
                 pending_labels.append(step.label or "")
+                if step.complete_task is not None:
+                    pending_complete_task[0] = step.complete_task
+                    flush_actions()
                 continue
 
             if isinstance(step, MissionStepWait):
@@ -152,6 +169,9 @@ class InOrbitToMirTranslator:
                     )
                 )
                 pending_labels.append(step.label or "")
+                if step.complete_task is not None:
+                    pending_complete_task[0] = step.complete_task
+                    flush_actions()
                 continue
 
             if isinstance(step, MissionStepRunAction) and step.action_id in NESTABLE_MIR_ACTIONS:
@@ -163,6 +183,9 @@ class InOrbitToMirTranslator:
                     )
                 )
                 pending_labels.append(step.label or "")
+                if step.complete_task is not None:
+                    pending_complete_task[0] = step.complete_task
+                    flush_actions()
                 continue
 
             # Non-nestable step — flush pending actions first

--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -13,7 +13,7 @@
 #     unbounded radian angle (e.g. 6.35 rad -> 364deg).
 #   - 2026-06-27: renamed local n -> n_pending_actions in flush_actions
 #   - 2026-06-27: waypoint_count via sum(map(...)) instead of a generator expression
-#   - 2026-06-27: preserve InOrbit per-task tracking (spec §11.1). A grouped (nestable) step
+#   - 2026-06-27: preserve InOrbit per-task tracking. A grouped (nestable) step
 #     carrying complete_task now flushes the current native group and stamps complete_task onto
 #     the emitted MissionStepExecuteMirNativeMission, so the task is reported (it lands in
 #     Mission.tasks_list and the tree builder's decorator emits TaskStarted/TaskCompletedNode).
@@ -107,11 +107,20 @@ class InOrbitToMirTranslator:
         pending_labels: list[str] = []
         # complete_task to stamp onto the next flushed native group, so InOrbit per-task
         # tracking survives the grouping (set when a grouped step carries complete_task).
-        pending_complete_task: list[Union[str, None]] = [None]
+        pending_complete_task: Union[str, None] = None
 
         def flush_actions():
+            """Emit the buffered actions as one native MiR mission step.
+
+            Builds a ``MissionStepExecuteMirNativeMission`` from the pending
+            waypoints and actions, derives its label from their count and kind,
+            stamps ``completeTask`` when one is pending, appends it to
+            ``translated_steps``, and clears the buffers. A no-op (beyond
+            resetting the pending task) when nothing is buffered.
+            """
+            nonlocal pending_complete_task
             if not pending_actions:
-                pending_complete_task[0] = None
+                pending_complete_task = None
                 return
             n_pending_actions = len(pending_actions)
             waypoint_count = sum(map(lambda a: isinstance(a, MirWaypoint), pending_actions))
@@ -133,12 +142,12 @@ class InOrbitToMirTranslator:
             }
             # Only set completeTask when present: the field is typed ``str`` (default None),
             # so passing None explicitly fails validation.
-            if pending_complete_task[0] is not None:
-                native_kwargs["completeTask"] = pending_complete_task[0]
+            if pending_complete_task is not None:
+                native_kwargs["completeTask"] = pending_complete_task
             translated_steps.append(MissionStepExecuteMirNativeMission(**native_kwargs))
             pending_actions.clear()
             pending_labels.clear()
-            pending_complete_task[0] = None
+            pending_complete_task = None
 
         for step in mission.definition.steps:
             if isinstance(step, MissionStepPoseWaypoint):
@@ -156,7 +165,7 @@ class InOrbitToMirTranslator:
                 )
                 pending_labels.append(step.label or "")
                 if step.complete_task is not None:
-                    pending_complete_task[0] = step.complete_task
+                    pending_complete_task = step.complete_task
                     flush_actions()
                 continue
 
@@ -170,7 +179,7 @@ class InOrbitToMirTranslator:
                 )
                 pending_labels.append(step.label or "")
                 if step.complete_task is not None:
-                    pending_complete_task[0] = step.complete_task
+                    pending_complete_task = step.complete_task
                     flush_actions()
                 continue
 
@@ -184,7 +193,7 @@ class InOrbitToMirTranslator:
                 )
                 pending_labels.append(step.label or "")
                 if step.complete_task is not None:
-                    pending_complete_task[0] = step.complete_task
+                    pending_complete_task = step.complete_task
                     flush_actions()
                 continue
 

--- a/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
@@ -8,6 +8,10 @@
 #
 # Modifications from upstream:
 #   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
+#   - 2026-06-27: apply the SDK step-node decorator in build_tree_for_mission so per-task
+#     mission tracking (TaskStarted/TaskCompletedNode), robot locking (LockRobotNode) and
+#     per-step timeouts (TimeoutNode) are restored for edge missions (spec §11.1). Upstream
+#     dropped the decorator, so only the final task list was reported.
 
 """Tree builder for MiR missions with compiled native mission steps."""
 
@@ -64,6 +68,11 @@ class MirTreeBuilder(DefaultTreeBuilder):
         tree.add_node(MissionInProgressNode(context, label="mission start"))
 
         step_builder = MirNodeFromStepBuilder(context)
+        # Restore per-step mission tracking: the decorator wraps each step node with
+        # LockRobotNode, an optional TimeoutNode, and TaskStarted/TaskCompletedNode (the
+        # latter only when the step carries a complete_task). Patches the builder's visit_*
+        # methods in place, so it must run before the steps are visited below.
+        step_builder.add_step_node_decorator(self._build_step_decorator_for_context(context))
 
         for ix, step in enumerate(mission.definition.steps):
             try:

--- a/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
@@ -8,9 +8,9 @@
 #
 # Modifications from upstream:
 #   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
-#   - 2026-06-27: apply the SDK step-node decorator in build_tree_for_mission so per-task
+#   - 2026-06-27: apply the step-node decorator in build_tree_for_mission so per-task
 #     mission tracking (TaskStarted/TaskCompletedNode), robot locking (LockRobotNode) and
-#     per-step timeouts (TimeoutNode) are restored for edge missions (spec §11.1). Upstream
+#     per-step timeouts (TimeoutNode) are restored for edge missions. Upstream
 #     dropped the decorator, so only the final task list was reported.
 
 """Tree builder for MiR missions with compiled native mission steps."""
@@ -30,6 +30,7 @@ from inorbit_edge_executor.behavior_tree import (
     register_accepted_node_types,
 )
 from inorbit_edge_executor.inorbit import MissionStatus
+
 from inorbit_mir_connector.src.mission.behavior_tree import (
     MirBehaviorTreeBuilderContext,
     MirMissionAbortedNode,

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_exec.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Wiring tests for MirWorkerPool (spec §4.5).
+"""Wiring tests for MirWorkerPool.
 
 Confirms the worker pool routes the SDK mission engine through the vendored
 mission module: native tree builder, translation, context construction, and
@@ -21,7 +21,9 @@ from inorbit_edge_executor.datatypes import (
 )
 from inorbit_edge_executor.mission import Mission
 
-from inorbit_mir_connector.src.mission.behavior_tree import MirBehaviorTreeBuilderContext
+from inorbit_mir_connector.src.mission.behavior_tree import (
+    MirBehaviorTreeBuilderContext,
+)
 from inorbit_mir_connector.src.mission.datatypes import (
     MirInOrbitMission,
     MissionStepExecuteMirNativeMission,

--- a/mir_connector/inorbit_mir_connector/tests/test_per_task_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_per_task_tracking.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-"""Per-task mission tracking for edge missions (spec §11.1).
+"""Per-task mission tracking for edge missions.
 
 Two regressions are covered:
 

--- a/mir_connector/inorbit_mir_connector/tests/test_per_task_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_per_task_tracking.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Per-task mission tracking for edge missions (spec §11.1).
+
+Two regressions are covered:
+
+  * The translator dropped ``complete_task`` when grouping waypoint/nestable
+    steps into a native MiR mission, so ``Mission.tasks_list`` came out empty
+    and InOrbit had no tasks to display.
+  * ``MirTreeBuilder`` skipped the SDK step-node decorator, so no
+    ``TaskStarted``/``TaskCompletedNode`` (nor ``LockRobotNode``) were emitted
+    for any step.
+
+These tests pin both the translator's task preservation and the tree builder's
+decorator wiring.
+"""
+
+from __future__ import annotations
+
+import unittest.mock as mock
+from types import SimpleNamespace
+
+from inorbit_edge_executor.behavior_tree import (
+    LockRobotNode,
+    TaskCompletedNode,
+    TaskStartedNode,
+)
+from inorbit_edge_executor.datatypes import (
+    MissionDefinition,
+    MissionRuntimeOptions,
+    MissionRuntimeSharedMemory,
+    MissionStepPoseWaypoint,
+    MissionStepRunAction,
+    MissionStepWait,
+    Pose,
+)
+from inorbit_edge_executor.mission import Mission
+
+from inorbit_mir_connector.src.mission.datatypes import MissionStepExecuteMirNativeMission
+from inorbit_mir_connector.src.mission.translator import InOrbitToMirTranslator
+from inorbit_mir_connector.src.mission_exec import MirWorkerPool
+
+ROBOT_ID = "mir-1"
+
+
+def _wp(x, y, theta=0.0, label="wp", complete_task=None):
+    kwargs = {"waypoint": Pose(x=x, y=y, theta=theta), "label": label}
+    if complete_task is not None:
+        kwargs["completeTask"] = complete_task
+    return MissionStepPoseWaypoint(**kwargs)
+
+
+def _run_action(action_id, label="action", complete_task=None):
+    kwargs = {"runAction": {"actionId": action_id}, "label": label}
+    if complete_task is not None:
+        kwargs["completeTask"] = complete_task
+    return MissionStepRunAction(**kwargs)
+
+
+def _mission(steps):
+    return Mission(
+        id="m1",
+        robot_id=ROBOT_ID,
+        definition=MissionDefinition(label="t", steps=steps),
+    )
+
+
+def _task_ids(mission):
+    return [t.task_id for t in (mission.tasks_list or [])]
+
+
+# --------------------------------------------------------------------------- #
+# Translator: complete_task preservation
+# --------------------------------------------------------------------------- #
+
+
+class TestTranslatorPreservesCompleteTask:
+    def test_grouped_waypoint_task_is_preserved(self):
+        m = _mission([_wp(1, 2, complete_task="task-1")])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.complete_task == "task-1"
+        # The task must reach the mission's tasks_list (what InOrbit displays).
+        assert _task_ids(result) == ["task-1"]
+
+    def test_task_boundary_flushes_group(self):
+        # task on a middle waypoint flushes the group at that point.
+        m = _mission([_wp(1, 2), _wp(3, 4, complete_task="t1"), _wp(5, 6)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 2
+        first, second = result.definition.steps
+        assert isinstance(first, MissionStepExecuteMirNativeMission)
+        assert [type(a).__name__ for a in first.actions] == ["MirWaypoint", "MirWaypoint"]
+        assert first.complete_task == "t1"
+        # trailing waypoint forms its own native group with no task.
+        assert isinstance(second, MissionStepExecuteMirNativeMission)
+        assert len(second.actions) == 1
+        assert second.complete_task is None
+        assert _task_ids(result) == ["t1"]
+
+    def test_multiple_tasks_each_reported(self):
+        m = _mission(
+            [
+                _wp(1, 2, complete_task="t1"),
+                _wp(3, 4),
+                MissionStepWait(timeoutSecs=5, label="w", completeTask="t2"),
+            ]
+        )
+        result = InOrbitToMirTranslator.translate(m)
+        assert _task_ids(result) == ["t1", "t2"]
+
+    def test_consecutive_no_task_waypoints_still_group(self):
+        # Behaviour unchanged when no step carries complete_task.
+        m = _mission([_wp(1, 2), _wp(3, 4), _wp(5, 6)])
+        result = InOrbitToMirTranslator.translate(m)
+        assert len(result.definition.steps) == 1
+        assert result.definition.steps[0].complete_task is None
+        assert _task_ids(result) == []
+
+    def test_non_nestable_passthrough_keeps_task(self):
+        # A non-nestable run_action passes through unchanged and keeps its task.
+        m = _mission(
+            [
+                _wp(1, 2),
+                _run_action("unknown_action", complete_task="t-pass"),
+                _wp(3, 4),
+            ]
+        )
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 3
+        passthrough = result.definition.steps[1]
+        assert isinstance(passthrough, MissionStepRunAction)
+        assert passthrough.complete_task == "t-pass"
+        assert _task_ids(result) == ["t-pass"]
+
+
+# --------------------------------------------------------------------------- #
+# Tree builder: decorator wiring
+# --------------------------------------------------------------------------- #
+
+
+def _build_tree(mission):
+    pool = MirWorkerPool(
+        mir_api=mock.MagicMock(),
+        api=mock.MagicMock(),
+        db=mock.MagicMock(),
+        missions_group=SimpleNamespace(missions_group_id="grp"),
+        firmware_version="v3",
+        connector_type="mir",
+    )
+    translated = pool.translate_mission(mission)
+    ctx = pool.create_builder_context()
+    pool.prepare_builder_context(ctx, translated)
+    ctx.shared_memory = MissionRuntimeSharedMemory()
+    ctx.options = MissionRuntimeOptions()
+    tree = pool._behavior_tree_builder.build_tree_for_mission(ctx)
+    nodes = []
+    tree.collect_nodes(nodes)
+    return nodes
+
+
+def test_tree_emits_task_nodes_for_task_bearing_step():
+    nodes = _build_tree(_mission([_wp(1, 2, complete_task="task-1")]))
+    assert any(isinstance(n, TaskStartedNode) for n in nodes)
+    assert any(isinstance(n, TaskCompletedNode) for n in nodes)
+    # LockRobotNode is always added by the decorator (no-op unless use_locks).
+    assert any(isinstance(n, LockRobotNode) for n in nodes)
+
+
+def test_tree_has_no_task_nodes_without_complete_task():
+    nodes = _build_tree(_mission([_wp(1, 2), _wp(3, 4)]))
+    assert not any(isinstance(n, TaskStartedNode) for n in nodes)
+    assert not any(isinstance(n, TaskCompletedNode) for n in nodes)
+    # decorator still runs, so robot-lock nodes are present.
+    assert any(isinstance(n, LockRobotNode) for n in nodes)


### PR DESCRIPTION
## Summary

Edge missions stopped reporting InOrbit per-task progress after native mission translation was added. This restores it by fixing two issues.

## Changes

`MirTreeBuilder.build_tree_for_mission` now applies the inherited SDK step-node decorator, so `LockRobotNode`, the optional `TimeoutNode`, and `TaskStarted`/`TaskCompletedNode` are emitted again for every step. The override previously skipped the decorator, so only the final task list was reported.

The translator no longer drops `complete_task` when grouping waypoint and nestable-action steps into a native MiR mission. A grouped step carrying `complete_task` now flushes the current native group and stamps the task onto the emitted step, so it reaches `Mission.tasks_list` and gets reported. Non-nestable steps already pass through and keep their task, and grouping is byte-identical for missions whose steps carry no `complete_task`, so existing behavior is unaffected.

A native MiR mission runs atomically on the robot, so intra-group task ordering is not observable; flushing the group at a task boundary keeps per-task reporting accurate (a task completes when its native sub-mission does) while still grouping consecutive task-free waypoints.

`tree_builder.py` and `translator.py` are vendored under `src/mission/`; the changes are functional only and recorded in each file's modifications header.
