### PR TITLE
MiR connector: make the missing-missions-group error operator-actionable

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -19,6 +19,8 @@
 #     so other queued/fleet missions survive; no fallback when the queue id is absent
 #   - 2026-06-27: CleanupMirMissionNode.__init__ now stores context.shared_memory (needed
 #     to read the queue id for the scoped abort above)
+#   - 2026-06-27: made the missing-missions-group runtime error operator-actionable (names the
+#     two fixes: enable_temporary_mission_group, or configure a predefined missions group)
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -148,7 +150,11 @@ class CreateMirNativeMissionNode(BehaviorTree):
         logger.info(f"Creating MiR native mission with {n_actions} actions: {mission_guid}")
 
         if not self._missions_group_id:
-            error_msg = "No missions group available for creating native MiR mission"
+            error_msg = (
+                "Cannot create native MiR mission: no MiR missions group is configured. "
+                "Enable 'enable_temporary_mission_group' in the connector config, or configure "
+                "a predefined missions group, then retry."
+            )
             logger.error(error_msg)
             self._shared_memory.set(SharedMemoryKeys.MIR_ERROR_MESSAGE, error_msg)
             raise RuntimeError(error_msg)

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
@@ -173,11 +173,14 @@ async def test_missing_missions_group_raises():
         api, [MirWaypoint(label="wp", x=1, y=2, orientation=0)], missions_group_id=None
     )
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="enable_temporary_mission_group"):
         await node._execute()
 
     assert api.created == []
-    assert ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+    # The operator-facing error names both remedies so it is actionable.
+    error_msg = ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+    assert "enable_temporary_mission_group" in error_msg
+    assert "predefined missions group" in error_msg
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When no MiR missions group is configured (the connector has neither a temporary group nor a predefined one), `CreateMirNativeMissionNode` aborts every native mission mid-flight with a terse "No missions group available" message that does not tell the operator how to fix it. This makes that error actionable.

## Changes

The runtime error now names the two remedies: enable `enable_temporary_mission_group` in the connector config, or configure a predefined missions group. `behavior_tree.py` is vendored under `src/mission/`; the change is functional only and logged in its modifications header.

This PR is stacked on `b-Tomas/mir-resume-hardening` because both touch the vendored `behavior_tree.py`; review or merge that one first, or rebase.

## Demo

<img width="623" height="341" alt="image" src="https://github.com/user-attachments/assets/e2b2b9be-4fc6-457b-b71f-dd47267dd3cc" />
