### PR TITLE
MiR connector: enforce native-mission completion timeout

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -19,6 +19,11 @@
 #     Mission.tasks_list and the tree builder's decorator emits TaskStarted/TaskCompletedNode).
 #     Non-nestable steps already pass through verbatim and keep their complete_task. Grouping is
 #     unchanged for missions whose steps carry no complete_task.
+#   - 2026-06-28: enforce native-mission timeout. The translator now stamps timeout_secs onto the
+#     emitted native step as the SUM of the grouped steps' timeout_secs, but ONLY when every
+#     grouped step is bounded; if any grouped step has no timeout the native step stays unbounded
+#     (preserving prior behavior). WaitForMirMissionCompletionNode then bounds its completion poll
+#     instead of polling indefinitely.
 
 """Mission translator that compiles consecutive InOrbit waypoint and
 nestable action steps into single native MiR missions.
@@ -108,6 +113,9 @@ class InOrbitToMirTranslator:
         # complete_task to stamp onto the next flushed native group, so InOrbit per-task
         # tracking survives the grouping (set when a grouped step carries complete_task).
         pending_complete_task: Union[str, None] = None
+        # timeout_secs of each grouped step (None if a step is unbounded), parallel to
+        # pending_actions, so the flushed native step can carry an aggregate timeout.
+        pending_timeouts: list[Union[float, None]] = []
 
         def flush_actions():
             """Emit the buffered actions as one native MiR mission step.
@@ -121,6 +129,7 @@ class InOrbitToMirTranslator:
             nonlocal pending_complete_task
             if not pending_actions:
                 pending_complete_task = None
+                pending_timeouts.clear()
                 return
             n_pending_actions = len(pending_actions)
             waypoint_count = sum(map(lambda a: isinstance(a, MirWaypoint), pending_actions))
@@ -144,10 +153,17 @@ class InOrbitToMirTranslator:
             # so passing None explicitly fails validation.
             if pending_complete_task is not None:
                 native_kwargs["completeTask"] = pending_complete_task
+            # Bound the completion poll only when every grouped step is bounded; the native
+            # mission's timeout is the sum of the grouped steps' timeouts. If any step is
+            # unbounded the native step stays unbounded (no premature abort). The field is
+            # typed float (default None), so only set it when computed.
+            if pending_timeouts and all(t is not None for t in pending_timeouts):
+                native_kwargs["timeoutSecs"] = sum(pending_timeouts)
             translated_steps.append(MissionStepExecuteMirNativeMission(**native_kwargs))
             pending_actions.clear()
             pending_labels.clear()
             pending_complete_task = None
+            pending_timeouts.clear()
 
         for step in mission.definition.steps:
             if isinstance(step, MissionStepPoseWaypoint):
@@ -164,6 +180,7 @@ class InOrbitToMirTranslator:
                     MirWaypoint(label=step.label, x=x, y=y, orientation=orientation_deg)
                 )
                 pending_labels.append(step.label or "")
+                pending_timeouts.append(step.timeout_secs)
                 if step.complete_task is not None:
                     pending_complete_task = step.complete_task
                     flush_actions()
@@ -178,6 +195,7 @@ class InOrbitToMirTranslator:
                     )
                 )
                 pending_labels.append(step.label or "")
+                pending_timeouts.append(step.timeout_secs)
                 if step.complete_task is not None:
                     pending_complete_task = step.complete_task
                     flush_actions()
@@ -192,6 +210,7 @@ class InOrbitToMirTranslator:
                     )
                 )
                 pending_labels.append(step.label or "")
+                pending_timeouts.append(step.timeout_secs)
                 if step.complete_task is not None:
                     pending_complete_task = step.complete_task
                     flush_actions()

--- a/mir_connector/inorbit_mir_connector/tests/test_native_timeout.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_native_timeout.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Native-mission completion timeout (translator timeout aggregation).
+
+The translator never set a timeout on the compiled
+``MissionStepExecuteMirNativeMission``, so ``WaitForMirMissionCompletionNode``
+polled the MiR mission queue forever. The translator now stamps ``timeout_secs``
+onto the emitted native step as the SUM of the grouped steps' ``timeout_secs``,
+but ONLY when every grouped step is bounded; if any grouped step is unbounded the
+native step stays unbounded (preserving prior behavior).
+
+These tests pin that aggregation.
+"""
+
+from __future__ import annotations
+
+from inorbit_edge_executor.datatypes import (
+    MissionDefinition,
+    MissionStepPoseWaypoint,
+    MissionStepWait,
+    Pose,
+)
+from inorbit_edge_executor.mission import Mission
+
+from inorbit_mir_connector.src.mission.datatypes import MissionStepExecuteMirNativeMission
+from inorbit_mir_connector.src.mission.translator import InOrbitToMirTranslator
+
+ROBOT_ID = "mir-1"
+
+
+def _wp(timeout=None, x=1.0, y=2.0, theta=0.0, label="wp", complete_task=None):
+    kwargs = {"waypoint": Pose(x=x, y=y, theta=theta), "label": label}
+    if timeout is not None:
+        kwargs["timeoutSecs"] = timeout
+    if complete_task is not None:
+        kwargs["completeTask"] = complete_task
+    return MissionStepPoseWaypoint(**kwargs)
+
+
+def _wait(timeout, label="wait"):
+    return MissionStepWait(timeoutSecs=timeout, label=label)
+
+
+def _mission(steps):
+    return Mission(
+        id="m1",
+        robot_id=ROBOT_ID,
+        definition=MissionDefinition(label="t", steps=steps),
+    )
+
+
+class TestNativeMissionTimeout:
+    def test_all_bounded_waypoints_sum(self):
+        # [wp(10), wp(20)] -> one native step with timeout 30.
+        m = _mission([_wp(10), _wp(20)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.timeout_secs == 30
+
+    def test_any_unbounded_step_leaves_native_unbounded(self):
+        # [wp(10), wp()] -> native step unbounded (no premature abort).
+        m = _mission([_wp(10), _wp()])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.timeout_secs is None
+
+    def test_single_bounded_waypoint(self):
+        # [wp(15)] -> timeout 15.
+        m = _mission([_wp(15)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.timeout_secs == 15
+
+    def test_wait_duration_contributes(self):
+        # [wp(10), wait(5)] -> timeout 15.
+        m = _mission([_wp(10), _wait(5)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.timeout_secs == 15
+
+    def test_no_timeouts_anywhere_stays_unbounded(self):
+        # [wp(), wp()] -> unbounded (parity with old behavior).
+        m = _mission([_wp(), _wp()])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.timeout_secs is None
+
+    def test_task_boundary_split_computes_per_group(self):
+        # [wp(10, completeTask="t1"), wp(20)] -> first native step timeout 10,
+        # second native step unbounded (no timeout aggregated across the split).
+        m = _mission([_wp(10, complete_task="t1"), _wp(20)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 2
+        first, second = result.definition.steps
+        assert isinstance(first, MissionStepExecuteMirNativeMission)
+        assert first.timeout_secs == 10
+        assert isinstance(second, MissionStepExecuteMirNativeMission)
+        assert second.timeout_secs == 20


### PR DESCRIPTION
## Summary

Native missions polled the MiR mission queue indefinitely because the translator never set a timeout on the compiled native step. This bounds the completion poll using the InOrbit per-step timeouts.

## Changes

When grouping waypoint and nestable-action steps into a native MiR mission, the translator now stamps timeout_secs onto the emitted step as the sum of the grouped steps' timeout_secs, but only when every grouped step is bounded; if any grouped step has no timeout the native step stays unbounded, preserving prior behavior. WaitForMirMissionCompletionNode already consumes the step timeout, so it now bounds its poll instead of running forever. translator.py is vendored under src/mission/; the change is functional only and logged in its modifications header.

This PR is stacked on b-Tomas/mir-per-task-tracking because both modify the translator's grouping; review or merge that one first, or rebase.

## Testing

New tests/test_native_timeout.py covers timeout aggregation (sum when all bounded, unbounded when any step lacks a timeout, single bounded step, wait duration contributes, task-boundary split). Full suite green, black and flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
