### PR TITLE
MiR connector: run native MiR actions as mission steps

### DIFF
--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -19,7 +19,7 @@ The [InOrbit](https://inorbit.ai/) Robot Connector for [MiR Motors](https://dire
 ## ✨ Features
 
 - **Real-time Monitoring**: Robot pose, system status, battery levels, and error states
-- **Mission Control**: Dispatch, pause, cancel missions via [Actions](https://developer.inorbit.ai/docs#configuring-action-definitions)
+- **Mission Control**: Dispatch, pause, cancel missions via [Actions](https://developer.inorbit.ai/docs#configuring-action-definitions), including [running MiR robot actions as mission steps](#-running-mir-actions-in-missions)
 - **Custom Scripts**: Execute custom shell scripts on the connector via Custom Actions
 - **Mission Tracking**: Full [Mission Tracking](https://developer.inorbit.ai/docs#configuring-mission-tracking) support
 - **SSL Support**: Secure connections with full certificate validation
@@ -712,6 +712,95 @@ docker compose -f docker-compose.example.yaml -f docker-compose.metrics.example.
 ```
 
 Set `GCP_PROJECT` and provide a service-account key (or switch to the `debug` exporter for local verification). For the full GCP setup and the design rules the config follows, see `inorbit-connector-python/examples/metrics/`.
+
+## 🤖 Running MiR Actions in Missions
+
+A mission `runAction` step can run any action from the MiR robot's action catalog (docking, charging,
+I/O, sound, and so on). Set `mir_actionType` to the action type, and add each of the action's
+parameters as a sibling argument:
+
+```yaml
+apiVersion: v0.1
+kind: MissionDefinition
+metadata:
+  id: mir-dock-and-charge
+  scope: account/<ACCOUNT_ID>
+spec:
+  label: "Dock and charge"
+  steps:
+    - label: "Dock at charger"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: docking
+          marker: "<position-guid>"
+    - label: "Charge to 80%"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: charging
+          minimum_time: "00:10:00.000000"
+          minimum_percentage: 80
+          charge_until_new_mission: true
+```
+
+- `mir_actionType` is the MiR action type. A step without it runs as a normal InOrbit action; if it is
+  set but empty, the mission is rejected.
+- `actionId` is required by the schema but ignored for these steps; use any stable value.
+- Every other argument is a MiR action parameter, named by its parameter `id` and sent to the robot as
+  written.
+
+More examples are in [`cac_examples/native_mission.yaml`](cac_examples/native_mission.yaml); apply them
+with the [InOrbit CLI](https://developer.inorbit.ai/docs#using-the-inorbit-cli).
+
+### Parameter value types
+
+MiR type-checks each parameter, so supply the type and format it expects:
+
+- **Duration**: a string formatted `HH:MM:SS.ffffff` (90.5 seconds is `"00:01:30.500000"`); a plain
+  number of seconds is rejected. Applies to `wait.time`, `charging.minimum_time`, the `*.timeout`
+  parameters, `sound.duration`, and similar.
+- **Reference**: the target object's GUID, not its display name. The connector does not resolve names to
+  GUIDs, except `docking.marker_type`, which it derives from the docking `marker`. PLC registers
+  (`set_plc_register.register`, `wait_for_plc_register.register`) take an integer id (1-200), not a GUID.
+- **Selection**: the exact option value, not its label (`operation` is `"on"`/`"off"`, `release_cart` is
+  `"yes"`/`"no"`, `light.color_1` is a hex string such as `"#ff0000"`).
+- **Number / Boolean**: an unquoted JSON literal (`80`, `true`), never a quoted string (`"true"`).
+- **String**: a plain string; some parameters reject an empty string (`throw_error.message`,
+  `create_autolog.description`, `email.subject`/`message`, `run_ur_program.program_name`).
+
+### Finding action types
+
+`GET /actions` lists the action types a robot supports, and `GET /actions/{type}` returns one type's
+parameters (id, type, constraints). Both vary by MiR model and firmware.
+
+```bash
+curl -u <user>:<pass> https://<robot-host>/api/v2.0.0/actions
+curl -u <user>:<pass> https://<robot-host>/api/v2.0.0/actions/docking
+```
+
+Some actions cannot be used as a step and are rejected before the mission starts:
+
+| Action | Use instead |
+|---|---|
+| `if`, `while`, `loop`, `try_catch`, `prompt_user`, `reduce_protective_fields` | InOrbit mission steps for control flow |
+| `set_reset_io` | `set_io` |
+| `set_reset_plc` | `set_plc_register` |
+| `break`, `continue` | (only valid inside a loop) |
+
+For navigation and waits, prefer the InOrbit `waypoint` and `timeoutSecs` mission steps rather than the
+`move_to_position` and `wait` actions. To run an existing MiR mission inline, use `load_mission` with `mission_id` set
+to that mission's GUID.
+
+### Limitations
+
+- Parameter ids and values are not validated before dispatch. A bad value is reported as the mission's
+  failure reason, but an unknown parameter id may be silently ignored by the robot, so the action runs
+  without it and still reports success. Cross-check against `GET /actions/{type}`.
+- References must be GUIDs, except `docking.marker_type`.
+- A rejected action leaves an empty, unqueued mission in the connector's temporary missions group;
+  nothing runs on the robot.
+- A failure identifies the mission, not which step within it failed.
 
 ## Next steps
 

--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -798,8 +798,8 @@ to that mission's GUID.
   failure reason, but an unknown parameter id may be silently ignored by the robot, so the action runs
   without it and still reports success. Cross-check against `GET /actions/{type}`.
 - References must be GUIDs, except `docking.marker_type`.
-- A rejected action leaves an empty, unqueued mission in the connector's temporary missions group;
-  nothing runs on the robot.
+- A rejected action (blank or denied `mir_actionType`) fails during translation, before any mission
+  is created on the robot; nothing runs.
 - A failure identifies the mission, not which step within it failed.
 
 ## Next steps

--- a/mir_connector/cac_examples/README.md
+++ b/mir_connector/cac_examples/README.md
@@ -2,3 +2,5 @@
 
 The files in this folder contain example [configuration as code](https://developer.inorbit.ai/docs#summary) objects, useful to unlock the full capabilities of the MiR <> InOrbit Connector. They can be managed through the [InOrbit CLI](https://developer.inorbit.ai/docs#using-the-inorbit-cli).
 Please note that the features available on your account will depend on your [InOrbit Edition](https://www.inorbit.ai/pricing). Don't hesitate to contact support@inorbit.ai for more information.
+
+`native_mission.yaml` holds `MissionDefinition` examples that run MiR robot actions (dock, charge, set I/O, sound, nested missions) as mission steps via the `mir_actionType` argument. See [Running MiR Actions in Missions](../README.md#-running-mir-actions-in-missions) in the connector README for the parameter value types and how to find action types.

--- a/mir_connector/cac_examples/native_mission.yaml
+++ b/mir_connector/cac_examples/native_mission.yaml
@@ -1,0 +1,75 @@
+# MissionDefinition examples for the MiR <> InOrbit Connector.
+#
+# A `runAction` step runs a MiR robot action when its `arguments` set `mir_actionType` to the action
+# type. Every other argument is a MiR action parameter, named by its parameter id and sent to the
+# robot as written, so it must be the type/format MiR expects (see "Running MiR Actions in Missions"
+# in the connector README for the value types).
+#
+# `actionId` is required by the schema but ignored for these steps; use any stable value.
+#
+# MissionDefinition is account-scoped: fill `scope` with your account (e.g. `account/<ACCOUNT_ID>`)
+# before applying with the InOrbit CLI.
+
+apiVersion: v0.1
+kind: MissionDefinition
+metadata:
+  id: mir-dock-and-charge
+  # REQUIRED. MissionDefinition is account-scoped.
+  # scope: account/<ACCOUNT_ID>
+spec:
+  label: "Dock and charge"
+  steps:
+    # docking: `marker` is a position GUID. `marker_type` is auto-resolved by the connector from
+    # the marker's docking offset, so do NOT hand-author it.
+    - label: "Dock at charger"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: docking
+          marker: "<position-guid>"
+    # charging: Duration is the pre-formatted string HH:MM:SS.ffffff; the boolean is an unquoted
+    # JSON literal (not the string "true").
+    - label: "Charge to 80%"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: charging
+          minimum_time: "00:10:00.000000"
+          minimum_percentage: 80
+          charge_until_new_mission: true
+---
+apiVersion: v0.1
+kind: MissionDefinition
+metadata:
+  id: mir-native-action-samples
+  # scope: account/<ACCOUNT_ID>
+spec:
+  label: "MiR action samples"
+  steps:
+    # set_io: `module` is a Reference -> a resolved object GUID (no name-to-GUID lookup).
+    # `operation` is a Selection -> the exact choice value ("on"/"off").
+    - label: "Turn output on"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: set_io
+          module: "<io-module-guid>"
+          port: 1
+          operation: "on"
+    # sound: `sound` is a Reference GUID; `volume` is a bare number.
+    - label: "Beep"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: sound
+          sound: "<sound-guid>"
+          volume: 80
+          mode: "full"
+    # load_mission: embed a pre-existing MiR mission in-flow. `mission_id` is the child mission's
+    # GUID (no name-to-GUID lookup). load_mission is not advertised by GET /actions but is accepted.
+    - label: "Run subroutine mission"
+      runAction:
+        actionId: mir-action
+        arguments:
+          mir_actionType: load_mission
+          mission_id: "<child-mission-guid>"

--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -6,6 +6,7 @@ import base64
 import math
 import uuid
 
+import httpx
 import pytz
 from inorbit_connector.commands import CommandResultCode
 
@@ -584,6 +585,11 @@ class MirConnector(Connector):
         # publish mission data
         try:
             await self.mission_tracking.report_mission(self.status, self.metrics or {})
+        except httpx.HTTPError as e:
+            # Transient MiR API/connection errors (server disconnects, timeouts,
+            # 5xx after retries). Expected during network blips - log concisely
+            # without a traceback, matching _disconnect's best-effort pattern.
+            self._logger.warning(f"Error reporting mission: {e}")
         except Exception:
             self._logger.exception("Error reporting mission")
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
@@ -191,7 +191,7 @@ class MirApiBaseClass(ABC):
         try:
             return await self._record_request(method, endpoint, **kwargs)
         except httpx.HTTPStatusError as e:
-            body = e.response.text
+            body = (e.response.text or "").strip()
             self.logger.warning(
                 "MiR API %s %s -> %s: %s",
                 method,
@@ -199,7 +199,14 @@ class MirApiBaseClass(ABC):
                 e.response.status_code,
                 (body[:2000] if body else "<empty response body>"),
             )
-            raise
+            if not body:
+                raise
+            # Re-raise as HTTPStatusError (so should_retry_http_error still sees
+            # the status and retries 5xx/408/429) but with the MiR reason body
+            # folded into str(), so it reaches MIR_ERROR_MESSAGE, not just logs.
+            raise httpx.HTTPStatusError(
+                f"{e}: {body[:2000]}", request=e.request, response=e.response
+            ) from e
 
     @retry(
         wait=wait_exponential_jitter(initial=1, max=10),

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -203,15 +203,32 @@ class MirApiV2(MirApiBaseClass):
         return response.json()
 
     async def get_mission_queue_actions(self, queue_id):
-        """Actions executed so far for a queued mission (single light GET).
+        """Started+completed actions for a queued mission (single light GET).
 
-        ``GET /mission_queue/{id}/actions`` returns the executed-so-far action
-        list; its length is the mission's action-level progress (the same signal
-        robot-side mission tracking uses). Distinct from ``get_mission`` (4 GETs),
-        so it is light enough for the ~1 s completion poll.
+        ``GET /mission_queue/{id}/actions`` returns a shallow list,
+        ``[{"id": <int>, "url": ...}]`` -- only an integer execution id and a
+        url, no ``action_id``/``state``/``finished``. The list grows as the
+        mission runs (the last entry is the one executing). To resolve which
+        mission-definition action an entry is (its ``action_id``) and whether it
+        finished, fetch each entry via ``get_mission_queue_action``. Distinct
+        from ``get_mission`` (4 GETs), so it is light enough for the ~1 s poll.
         """
         actions_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{queue_id}/actions"
         response = await self._get(actions_api_url)
+        return response.json()
+
+    async def get_mission_queue_action(self, queue_id, action_int_id):
+        """Full detail of a single executed mission-queue action (single light GET).
+
+        ``GET /mission_queue/{id}/actions/{action_int_id}`` returns the rich
+        entry: ``{id, action_id, state, started, finished, action_type,
+        parameters}``. ``action_id`` equals the mission-definition action guid
+        (what ``add_action_to_mission`` returns), so it maps a running queue
+        action back to the action we created. Completion signal is ``finished``
+        (a timestamp once done); ``state`` can be ``""`` even when finished.
+        """
+        action_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{queue_id}/actions/{action_int_id}"
+        response = await self._get(action_api_url)
         return response.json()
 
     async def get_executing_mission_id(self):

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -202,6 +202,18 @@ class MirApiV2(MirApiBaseClass):
         response = await self._get(mission_api_url)
         return response.json()
 
+    async def get_mission_queue_actions(self, queue_id):
+        """Actions executed so far for a queued mission (single light GET).
+
+        ``GET /mission_queue/{id}/actions`` returns the executed-so-far action
+        list; its length is the mission's action-level progress (the same signal
+        robot-side mission tracking uses). Distinct from ``get_mission`` (4 GETs),
+        so it is light enough for the ~1 s completion poll.
+        """
+        actions_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{queue_id}/actions"
+        response = await self._get(actions_api_url)
+        return response.json()
+
     async def get_executing_mission_id(self):
         """Returns the id of the mission being currently executed by the robot"""
         missions_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}"

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -23,6 +23,12 @@
 #     two fixes: enable_temporary_mission_group, or configure a predefined missions group)
 #   - 2026-06-30: CreateMirNativeMissionNode.dump_object now dumps the step with by_alias=True
 #     so a bounded/tracked native step (timeoutSecs/completeTask) round-trips on resume
+#   - 2026-06-30: WaitForMirMissionCompletionNode now reports per-action InOrbit task
+#     progress. A grouped native step carries action_task_ids (parallel to its actions); the
+#     node maps the executed-action count (GET /mission_queue/{id}/actions, the signal
+#     robot-side mission tracking uses) to those tasks and marks each in_progress/completed
+#     as its action runs. Replaces the per-step TaskStarted/CompletedNode the SDK decorator
+#     can no longer emit once steps are grouped.
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -246,12 +252,85 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
         self,
         context: MirBehaviorTreeBuilderContext,
         timeout_secs: Optional[float] = None,
+        action_task_ids: Optional[list] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._mir_api = context.mir_api
         self._shared_memory = context.shared_memory
         self._timeout_secs = timeout_secs
+        # Ordered InOrbit task ids parallel to the native mission's actions (None = no task).
+        self._action_task_ids = action_task_ids or []
+        # mission/mt drive InOrbit per-task tracking; both are None outside a real dispatch
+        # (e.g. some unit tests), so _report_progress no-ops when either is missing.
+        self._mission = context.mission
+        self._mt = context.mt
+        # action index -> last reported status ("p"=in_progress, "c"=completed), to avoid
+        # re-reporting. Not serialized: on resume it re-derives from MiR (marking is
+        # idempotent, so a re-report is harmless).
+        self._reported: dict = {}
+
+    def _tracking_tasks(self) -> bool:
+        """True when this group has at least one task to report and the tracking
+        collaborators (mission + mt) are available."""
+        return (
+            self._mt is not None
+            and self._mission is not None
+            and any(t is not None for t in self._action_task_ids)
+        )
+
+    async def _report_progress(self, queue_id):
+        """Mark grouped tasks as their MiR actions run.
+
+        Ports robot-side mission tracking's action-count signal: the length of
+        ``GET /mission_queue/{id}/actions`` is how many of the native mission's
+        actions have run, mapped to the parallel ``action_task_ids``. Best-effort:
+        never raises into the completion poll.
+        """
+        if not self._tracking_tasks():
+            return
+        try:
+            done = len(await self._mir_api.get_mission_queue_actions(queue_id))
+        except Exception as e:
+            logger.warning(f"Failed to poll per-action progress for {queue_id}: {e}")
+            return
+        await self._mark(done)
+
+    async def _mark(self, done):
+        """Mark tasks for actions through index ``done``: the last started action
+        (index ``done - 1``) is in progress, earlier ones are completed."""
+        changed = False
+        for i in range(min(done, len(self._action_task_ids))):
+            task_id = self._action_task_ids[i]
+            if task_id is None:
+                continue
+            status = "c" if i < done - 1 else "p"
+            previous = self._reported.get(i)
+            if previous == status or previous == "c":  # no change / never downgrade
+                continue
+            if status == "c":
+                self._mission.mark_task_completed(task_id)
+            else:
+                self._mission.mark_task_in_progress(task_id)
+            self._reported[i] = status
+            changed = True
+        if changed:
+            await self._mt.report_tasks()
+
+    async def _finish_tasks(self):
+        """Mark every remaining task completed (the mission reached Done; covers a
+        fast group whose actions all flipped between polls)."""
+        if not self._tracking_tasks():
+            return
+        changed = False
+        for i, task_id in enumerate(self._action_task_ids):
+            if task_id is None or self._reported.get(i) == "c":
+                continue
+            self._mission.mark_task_completed(task_id)
+            self._reported[i] = "c"
+            changed = True
+        if changed:
+            await self._mt.report_tasks()
 
     async def _execute(self):
         queue_id = self._shared_memory.get(SharedMemoryKeys.MIR_QUEUE_ID)
@@ -289,7 +368,10 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
 
             state = entry.get("state", "")
 
+            await self._report_progress(queue_id)
+
             if state == MirMissionQueueState.DONE:
+                await self._finish_tasks()
                 logger.info(f"MiR mission {queue_id} completed successfully")
                 return
 
@@ -308,11 +390,15 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
         obj = super().dump_object()
         if self._timeout_secs is not None:
             obj["timeout_secs"] = self._timeout_secs
+        if self._action_task_ids:
+            obj["action_task_ids"] = self._action_task_ids
         return obj
 
     @classmethod
-    def from_object(cls, context, timeout_secs=None, **kwargs):
-        return WaitForMirMissionCompletionNode(context, timeout_secs=timeout_secs, **kwargs)
+    def from_object(cls, context, timeout_secs=None, action_task_ids=None, **kwargs):
+        return WaitForMirMissionCompletionNode(
+            context, timeout_secs=timeout_secs, action_task_ids=action_task_ids, **kwargs
+        )
 
 
 class MirMissionAbortedNode(MissionAbortedNode):
@@ -396,6 +482,7 @@ class MirNodeFromStepBuilder(NodeFromStepBuilder):
             WaitForMirMissionCompletionNode(
                 self._mir_context,
                 timeout_secs=step.timeout_secs,
+                action_task_ids=step.action_task_ids,
                 label=f"Wait for MiR mission '{step.label}'",
             )
         )

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -24,11 +24,16 @@
 #   - 2026-06-30: CreateMirNativeMissionNode.dump_object now dumps the step with by_alias=True
 #     so a bounded/tracked native step (timeoutSecs/completeTask) round-trips on resume
 #   - 2026-06-30: WaitForMirMissionCompletionNode now reports per-action InOrbit task
-#     progress. A grouped native step carries action_task_ids (parallel to its actions); the
-#     node maps the executed-action count (GET /mission_queue/{id}/actions, the signal
-#     robot-side mission tracking uses) to those tasks and marks each in_progress/completed
-#     as its action runs. Replaces the per-step TaskStarted/CompletedNode the SDK decorator
-#     can no longer emit once steps are grouped.
+#     progress, replacing the per-step TaskStarted/CompletedNode the SDK decorator can no
+#     longer emit once steps are grouped. A grouped native step carries action_task_ids
+#     (parallel to its actions). CreateMirNativeMissionNode captures the guid each
+#     add_action_to_mission returns into shared memory (MIR_ACTION_GUIDS, ordered parallel to
+#     the actions); the completion node pairs each guid with its task id, then per poll
+#     resolves each queued action's action_id (== that guid) via GET /mission_queue/{id}/
+#     actions/{int_id} and marks the paired task in_progress/completed from the action's
+#     `finished` timestamp. Matching by guid (not list length) ignores a load_mission's
+#     inlined sub-actions, whose guids are foreign to our set, so nested missions no longer
+#     over-complete. Best-effort: a tracking error never aborts the completion poll.
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -98,6 +103,10 @@ class SharedMemoryKeys(StrEnum):
     MIR_MISSION_GUID = "mir_mission_guid"
     MIR_QUEUE_ID = "mir_queue_id"
     MIR_ERROR_MESSAGE = "mir_error_message"
+    # Ordered guids of the created mission actions (parallel to the step's actions, and so
+    # to action_task_ids). Written by CreateMirNativeMissionNode, read by the completion node
+    # to pair each guid with its InOrbit task id. Serialized -> survives resume.
+    MIR_ACTION_GUIDS = "mir_action_guids"
 
 
 class MirBehaviorTreeBuilderContext(BehaviorTreeBuilderContext):
@@ -153,6 +162,7 @@ class CreateMirNativeMissionNode(BehaviorTree):
         self._shared_memory.add(SharedMemoryKeys.MIR_MISSION_GUID, None)
         self._shared_memory.add(SharedMemoryKeys.MIR_QUEUE_ID, None)
         self._shared_memory.add(SharedMemoryKeys.MIR_ERROR_MESSAGE, None)
+        self._shared_memory.add(SharedMemoryKeys.MIR_ACTION_GUIDS, None)
 
     async def _execute(self):
         actions = self._step.actions
@@ -179,6 +189,7 @@ class CreateMirNativeMissionNode(BehaviorTree):
                 description="Compiled mission created by InOrbit edge executor",
             )
 
+            action_guids = []
             for i, action in enumerate(actions):
                 if isinstance(action, MirWaypoint):
                     action_type = "move_to_position"
@@ -207,17 +218,23 @@ class CreateMirNativeMissionNode(BehaviorTree):
                     for k, v in param_values.items()
                 ]
 
-                await self._mir_api.add_action_to_mission(
+                created = await self._mir_api.add_action_to_mission(
                     action_type=action_type,
                     mission_id=mission_guid,
                     parameters=action_parameters,
                     priority=i + 1,
                 )
+                # action_id reported by the mission queue at runtime == this guid; the
+                # completion node matches on it to mark the paired InOrbit task. A missing
+                # guid (unexpected response shape) becomes None -> that task just falls back
+                # to mark-at-end rather than crashing the dispatch.
+                action_guids.append((created or {}).get("guid"))
 
             queue_response = await self._mir_api.queue_mission(mission_guid)
             queue_id = queue_response.get("id")
             self._shared_memory.set(SharedMemoryKeys.MIR_MISSION_GUID, mission_guid)
             self._shared_memory.set(SharedMemoryKeys.MIR_QUEUE_ID, queue_id)
+            self._shared_memory.set(SharedMemoryKeys.MIR_ACTION_GUIDS, action_guids)
             logger.info(f"Queued MiR native mission: {mission_guid} (queue id: {queue_id})")
 
         except DockingOffsetError as e:
@@ -269,6 +286,14 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
         # re-reporting. Not serialized: on resume it re-derives from MiR (marking is
         # idempotent, so a re-report is harmless).
         self._reported: dict = {}
+        # {our action guid -> InOrbit task id}, built lazily on first poll from
+        # MIR_ACTION_GUIDS (shared memory) zipped with action_task_ids. None until built.
+        self._guid_to_task: Optional[dict] = None
+        # queue-action int id -> (action_id, finished_bool). Once finished, never re-fetched,
+        # so steady state is ~1 detail GET/poll. Not serialized: re-derives on resume.
+        self._detail_cache: dict = {}
+        # warn once if our guids never match any queued action_id (fail-safe degradation).
+        self._warned_no_match = False
 
     def _tracking_tasks(self) -> bool:
         """True when this group has at least one task to report and the tracking
@@ -279,43 +304,77 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
             and any(t is not None for t in self._action_task_ids)
         )
 
-    async def _report_progress(self, queue_id):
-        """Mark grouped tasks as their MiR actions run.
+    def _build_pairing(self):
+        """Build ``{our action guid -> task id}`` from MIR_ACTION_GUIDS (set by
+        CreateMirNativeMissionNode) zipped with the parallel ``action_task_ids``."""
+        guids = self._shared_memory.get(SharedMemoryKeys.MIR_ACTION_GUIDS) or []
+        self._guid_to_task = {
+            g: t for g, t in zip(guids, self._action_task_ids) if g is not None and t is not None
+        }
 
-        Ports robot-side mission tracking's action-count signal: the length of
-        ``GET /mission_queue/{id}/actions`` is how many of the native mission's
-        actions have run, mapped to the parallel ``action_task_ids``. Best-effort:
-        never raises into the completion poll.
+    async def _report_progress(self, queue_id):
+        """Mark each grouped task as the MiR action it is paired with runs.
+
+        The queue action list (``GET /mission_queue/{id}/actions``) is shallow
+        (``[{id, url}]``); each entry's ``action_id`` and ``finished`` come from the
+        detail endpoint. ``action_id`` equals the guid we captured at creation, so we
+        map it back to the paired InOrbit task. A ``load_mission``'s inlined
+        sub-actions carry foreign guids and are simply not in the pairing, so they are
+        ignored. Best-effort: never raises into the completion poll.
         """
         if not self._tracking_tasks():
             return
+        if self._guid_to_task is None:
+            self._build_pairing()
+        if not self._guid_to_task:
+            return
         try:
-            done = len(await self._mir_api.get_mission_queue_actions(queue_id))
+            entries = await self._mir_api.get_mission_queue_actions(queue_id)
+            for entry in entries:
+                int_id = entry.get("id")
+                cached = self._detail_cache.get(int_id)
+                if cached is not None and cached[1]:  # already resolved as finished
+                    continue
+                detail = await self._mir_api.get_mission_queue_action(queue_id, int_id)
+                self._detail_cache[int_id] = (
+                    detail.get("action_id"),
+                    detail.get("finished") is not None,
+                )
         except Exception as e:
             logger.warning(f"Failed to poll per-action progress for {queue_id}: {e}")
             return
-        await self._mark(done)
+        finished_by_guid = {action_id: fin for action_id, fin in self._detail_cache.values()}
+        await self._mark(finished_by_guid, polled=bool(entries))
 
-    async def _mark(self, done):
-        """Mark tasks for actions through index ``done``: the last started action
-        (index ``done - 1``) is in progress, earlier ones are completed."""
+    async def _mark(self, finished_by_guid, polled):
+        """Mark each paired task from its action's queue state: present and finished
+        -> completed, present and running -> in progress, absent -> leave for later."""
         changed = False
-        for i in range(min(done, len(self._action_task_ids))):
-            task_id = self._action_task_ids[i]
-            if task_id is None:
-                continue
-            status = "c" if i < done - 1 else "p"
-            previous = self._reported.get(i)
+        matched = False
+        for guid, task_id in self._guid_to_task.items():
+            if guid not in finished_by_guid:
+                continue  # not started yet, or a foreign sub-action guid
+            matched = True
+            status = "c" if finished_by_guid[guid] else "p"
+            previous = self._reported.get(task_id)
             if previous == status or previous == "c":  # no change / never downgrade
                 continue
             if status == "c":
                 self._mission.mark_task_completed(task_id)
             else:
                 self._mission.mark_task_in_progress(task_id)
-            self._reported[i] = status
+            self._reported[task_id] = status
             changed = True
         if changed:
             await self._mt.report_tasks()
+        elif polled and not matched and not self._warned_no_match:
+            # The queue has actions but none carry our guids: granular tracking is
+            # degrading to mark-at-end (_finish_tasks still completes everything at Done).
+            self._warned_no_match = True
+            logger.warning(
+                "MiR per-task tracking: no queued action_id matched the created action "
+                "guids; tasks will be completed at mission end (action_id/guid mismatch?)"
+            )
 
     async def _finish_tasks(self):
         """Mark every remaining task completed (the mission reached Done; covers a
@@ -323,11 +382,11 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
         if not self._tracking_tasks():
             return
         changed = False
-        for i, task_id in enumerate(self._action_task_ids):
-            if task_id is None or self._reported.get(i) == "c":
+        for task_id in self._action_task_ids:
+            if task_id is None or self._reported.get(task_id) == "c":
                 continue
             self._mission.mark_task_completed(task_id)
-            self._reported[i] = "c"
+            self._reported[task_id] = "c"
             changed = True
         if changed:
             await self._mt.report_tasks()

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -21,6 +21,8 @@
 #     to read the queue id for the scoped abort above)
 #   - 2026-06-27: made the missing-missions-group runtime error operator-actionable (names the
 #     two fixes: enable_temporary_mission_group, or configure a predefined missions group)
+#   - 2026-06-30: CreateMirNativeMissionNode.dump_object now dumps the step with by_alias=True
+#     so a bounded/tracked native step (timeoutSecs/completeTask) round-trips on resume
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -226,7 +228,8 @@ class CreateMirNativeMissionNode(BehaviorTree):
 
     def dump_object(self):
         obj = super().dump_object()
-        obj["step"] = self._step.model_dump(mode="json", exclude_none=True)
+        # by_alias: step model is extra="forbid" alias-only; snake_case keys fail resume.
+        obj["step"] = self._step.model_dump(mode="json", exclude_none=True, by_alias=True)
         return obj
 
     @classmethod

--- a/mir_connector/inorbit_mir_connector/src/mission/datatypes.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/datatypes.py
@@ -7,7 +7,11 @@
 # Upstream commit: c516f7d9e8e6b8b3cbaa396e2984ce149c6e7925 (2026-05-21)
 #
 # Modifications from upstream:
-#   - none (verbatim; imports use inorbit_edge_executor.* and relative paths only)
+#   - 2026-06-30 Tomás Badenes: add action_task_ids to MissionStepExecuteMirNativeMission.
+#     Ordered InOrbit task ids parallel to actions (None = action has no task), so a grouped
+#     native mission reports each task as its MiR action runs instead of needing one native
+#     step per task. No alias (it is built internally, not parsed from InOrbit JSON), so it
+#     round-trips under every dump convention. Default empty for back-compat.
 
 """MiR-specific mission datatypes for mission translation.
 
@@ -64,6 +68,10 @@ class MissionStepExecuteMirNativeMission(MissionStep):
         description="Ordered actions for native MiR mission"
     )
     robot_id: str = Field(description="InOrbit robot ID")
+    action_task_ids: List[Union[str, None]] = Field(
+        default_factory=list,
+        description="InOrbit task ids parallel to actions (None = action has no task)",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -31,6 +31,11 @@
 #     from the action parameters (each surviving key is a MiR parameter id). Scope-bearing /
 #     control-flow / loop-only types are rejected before any robot-side mission exists via
 #     DENIED_NATIVE_ACTIONS. Zero surviving params warns. Spec: native-mission-action-steps.md.
+#   - 2026-06-30: group consecutive nestable steps even when each carries complete_task (no
+#     longer flush the native group per task). The per-action task ids ride on the native
+#     step (actionTaskIds, parallel to actions) and the original tasks_list is preserved, so
+#     InOrbit per-task tracking still reports each task as its MiR action runs while the
+#     whole group compiles into a single native mission.
 
 """Mission translator that compiles consecutive InOrbit waypoint and
 nestable action steps into single native MiR missions.
@@ -150,26 +155,25 @@ class InOrbitToMirTranslator:
         translated_steps: MirStepsList = []
         pending_actions: list[Union[MirWaypoint, MirAction]] = []
         pending_labels: list[str] = []
-        # complete_task to stamp onto the next flushed native group, so InOrbit per-task
-        # tracking survives the grouping (set when a grouped step carries complete_task).
-        pending_complete_task: Union[str, None] = None
         # timeout_secs of each grouped step (None if a step is unbounded), parallel to
         # pending_actions, so the flushed native step can carry an aggregate timeout.
         pending_timeouts: list[Union[float, None]] = []
+        # complete_task of each grouped step (None if untracked), parallel to
+        # pending_actions, so the native step can report each task as its MiR action runs.
+        pending_task_ids: list[Union[str, None]] = []
 
         def flush_actions():
             """Emit the buffered actions as one native MiR mission step.
 
             Builds a ``MissionStepExecuteMirNativeMission`` from the pending
             waypoints and actions, derives its label from their count and kind,
-            stamps ``completeTask`` when one is pending, appends it to
-            ``translated_steps``, and clears the buffers. A no-op (beyond
-            resetting the pending task) when nothing is buffered.
+            carries the per-action task ids (so each task is reported as its MiR
+            action runs), appends it to ``translated_steps``, and clears the
+            buffers. A no-op when nothing is buffered.
             """
-            nonlocal pending_complete_task
             if not pending_actions:
-                pending_complete_task = None
                 pending_timeouts.clear()
+                pending_task_ids.clear()
                 return
             n_pending_actions = len(pending_actions)
             waypoint_count = sum(map(lambda a: isinstance(a, MirWaypoint), pending_actions))
@@ -188,11 +192,11 @@ class InOrbitToMirTranslator:
                 "label": label,
                 "actions": list(pending_actions),
                 "robot_id": mission.robot_id,
+                # Per-action task ids (None where a step has no task), parallel to actions.
+                # The completion node marks each as its MiR action runs; the native step's
+                # own completeTask stays None so the SDK decorator adds no single-task wrap.
+                "action_task_ids": list(pending_task_ids),
             }
-            # Only set completeTask when present: the field is typed ``str`` (default None),
-            # so passing None explicitly fails validation.
-            if pending_complete_task is not None:
-                native_kwargs["completeTask"] = pending_complete_task
             # Bound the completion poll only when every grouped step is bounded; the native
             # mission's timeout is the sum of the grouped steps' timeouts. If any step is
             # unbounded the native step stays unbounded (no premature abort). The field is
@@ -202,8 +206,8 @@ class InOrbitToMirTranslator:
             translated_steps.append(MissionStepExecuteMirNativeMission(**native_kwargs))
             pending_actions.clear()
             pending_labels.clear()
-            pending_complete_task = None
             pending_timeouts.clear()
+            pending_task_ids.clear()
 
         for step in mission.definition.steps:
             if isinstance(step, MissionStepPoseWaypoint):
@@ -221,9 +225,7 @@ class InOrbitToMirTranslator:
                 )
                 pending_labels.append(step.label or "")
                 pending_timeouts.append(step.timeout_secs)
-                if step.complete_task is not None:
-                    pending_complete_task = step.complete_task
-                    flush_actions()
+                pending_task_ids.append(step.complete_task)
                 continue
 
             if isinstance(step, MissionStepWait):
@@ -236,9 +238,7 @@ class InOrbitToMirTranslator:
                 )
                 pending_labels.append(step.label or "")
                 pending_timeouts.append(step.timeout_secs)
-                if step.complete_task is not None:
-                    pending_complete_task = step.complete_task
-                    flush_actions()
+                pending_task_ids.append(step.complete_task)
                 continue
 
             if isinstance(step, MissionStepRunAction):
@@ -276,9 +276,7 @@ class InOrbitToMirTranslator:
                     )
                     pending_labels.append(step.label or "")
                     pending_timeouts.append(step.timeout_secs)
-                    if step.complete_task is not None:
-                        pending_complete_task = step.complete_task
-                        flush_actions()
+                    pending_task_ids.append(step.complete_task)
                     continue
                 # No exact reserved key: route to the cloud action path. Warn on a stray
                 # mir_-prefixed key so a fat-fingered type key fails loudly, not silently.
@@ -306,6 +304,9 @@ class InOrbitToMirTranslator:
             robot_id=mission.robot_id,
             definition=translated_definition,
             arguments=mission.arguments,
+            # Grouped native steps no longer expose complete_task to the task extractor, so
+            # pass the original per-step tasks through to keep InOrbit's task list intact.
+            tasks_list=mission.tasks_list,
         )
 
         logger.debug(

--- a/mir_connector/inorbit_mir_connector/src/mission/translator.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/translator.py
@@ -24,6 +24,13 @@
 #     grouped step is bounded; if any grouped step has no timeout the native step stays unbounded
 #     (preserving prior behavior). WaitForMirMissionCompletionNode then bounds its completion poll
 #     instead of polling indefinitely.
+#   - 2026-06-29: route runAction -> native MiR action by the reserved `mir_actionType`
+#     argument key instead of the NESTABLE_MIR_ACTIONS name-match (deleted). vda5050-parity:
+#     present-but-blank type is a hard error; a missing exact key routes to the cloud action
+#     path (warning when a stray mir_-prefixed key is present); the reserved key is excluded
+#     from the action parameters (each surviving key is a MiR parameter id). Scope-bearing /
+#     control-flow / loop-only types are rejected before any robot-side mission exists via
+#     DENIED_NATIVE_ACTIONS. Zero surviving params warns. Spec: native-mission-action-steps.md.
 
 """Mission translator that compiles consecutive InOrbit waypoint and
 nestable action steps into single native MiR missions.
@@ -61,21 +68,54 @@ from .datatypes import (
 
 logger = logging.getLogger(__name__)
 
-# MiR action types that can be nested into a compiled native mission.
-NESTABLE_MIR_ACTIONS: set[str] = {
-    "docking",
-    "charging",
-    "wait",
-    "relative_move",
-    "adjust_localization",
-    "set_plc_register",
-    "wait_for_plc_register",
-    "sound",
-    "sound_stop",
-    "light",
-    "pickup_cart",
-    "place_cart",
-    "set_footprint",
+# Reserved argument key that marks a runAction for native MiR translation (vda5050 parity:
+# the vda5050 connector uses a reserved-argument-key marker rather than a name allowlist).
+RESERVED_MIR_ARG_TYPE_KEY = "mir_actionType"
+RESERVED_MIR_ARG_KEYS = frozenset({RESERVED_MIR_ARG_TYPE_KEY})
+MIR_RESERVED_PREFIX = "mir_"
+
+# MiR action types that cannot be expressed as a single flat add_action_to_mission call,
+# rejected at translate time (before any create_mission, so no orphan mission is left on the
+# robot). Two reasons, grounded in live GET /actions/{type} schemas (MiR100, SW v2.0.0):
+#   - scope-bearing: the schema carries a Scope parameter (the container holding nested child
+#     actions); the connector has no scope_reference machinery, so the flat call would silently
+#     drop the body. For two of these the plain leaf action posts the useful part.
+#   - loop-only: break/continue carry no params but are only legal inside a Loop scope, so a
+#     flat top-level step is an orphaned firmware error.
+# (`return` is NOT denied: it is a valid top-level abort.)
+_SCOPE_BEARING_DENIED = (
+    "if",
+    "while",
+    "loop",
+    "try_catch",
+    "prompt_user",
+    "reduce_protective_fields",
+    "set_reset_io",
+    "set_reset_plc",
+)
+_LOOP_ONLY_DENIED = ("break", "continue")
+# Scope-wrapper types whose plain leaf action expresses the postable part without the body.
+_SCOPE_DENIED_ALTERNATIVE = {"set_reset_io": "set_io", "set_reset_plc": "set_plc_register"}
+_SCOPE_DENIED_REASON = (
+    "carries a Scope (child-action) body the connector cannot build as a flat native step; "
+    "the body would be silently dropped"
+)
+_LOOP_ONLY_DENIED_REASON = (
+    "is only valid inside a Loop scope; as a flat top-level native step it is an orphaned "
+    "firmware error"
+)
+
+
+def _scope_denied_message(action_type: str) -> str:
+    msg = f"'{action_type}' {_SCOPE_DENIED_REASON}"
+    alt = _SCOPE_DENIED_ALTERNATIVE.get(action_type)
+    return f"{msg}; use '{alt}' instead" if alt else msg
+
+
+# action_type -> operator-facing reason it cannot be a native step.
+DENIED_NATIVE_ACTIONS: dict[str, str] = {
+    **{a: _scope_denied_message(a) for a in _SCOPE_BEARING_DENIED},
+    **{a: f"'{a}' {_LOOP_ONLY_DENIED_REASON}" for a in _LOOP_ONLY_DENIED},
 }
 
 
@@ -201,20 +241,54 @@ class InOrbitToMirTranslator:
                     flush_actions()
                 continue
 
-            if isinstance(step, MissionStepRunAction) and step.action_id in NESTABLE_MIR_ACTIONS:
-                pending_actions.append(
-                    MirAction(
-                        label=step.label,
-                        action_type=step.action_id,
-                        parameters=step.arguments or {},
+            if isinstance(step, MissionStepRunAction):
+                # None-safe: MissionStepRunAction.arguments defaults to None.
+                args = step.arguments or {}
+                if RESERVED_MIR_ARG_TYPE_KEY in args:
+                    action_type = args.get(RESERVED_MIR_ARG_TYPE_KEY)
+                    if not isinstance(action_type, str) or not action_type.strip():
+                        raise ValueError(
+                            f"runAction step {step.label!r}: {RESERVED_MIR_ARG_TYPE_KEY} must be "
+                            f"a non-empty string"
+                        )
+                    action_type = action_type.strip()
+                    # Reject scope-bearing / control-flow types here, before create_mission,
+                    # so no orphan mission is created on the robot.
+                    if action_type in DENIED_NATIVE_ACTIONS:
+                        raise ValueError(
+                            f"runAction step {step.label!r}: {DENIED_NATIVE_ACTIONS[action_type]}"
+                        )
+                    # Each surviving (non-reserved) key is a MiR action parameter id. Extract by
+                    # exact reserved-key exclusion (not prefix-strip), matching vda5050.
+                    parameters = {k: v for k, v in args.items() if k not in RESERVED_MIR_ARG_KEYS}
+                    if not parameters:
+                        logger.warning(
+                            f"runAction step {step.label!r}: native MiR action {action_type!r} "
+                            f"has no parameters after excluding reserved keys (all params "
+                            f"mis-keyed?)"
+                        )
+                    pending_actions.append(
+                        MirAction(
+                            label=step.label,
+                            action_type=action_type,
+                            parameters=parameters,
+                        )
                     )
-                )
-                pending_labels.append(step.label or "")
-                pending_timeouts.append(step.timeout_secs)
-                if step.complete_task is not None:
-                    pending_complete_task = step.complete_task
-                    flush_actions()
-                continue
+                    pending_labels.append(step.label or "")
+                    pending_timeouts.append(step.timeout_secs)
+                    if step.complete_task is not None:
+                        pending_complete_task = step.complete_task
+                        flush_actions()
+                    continue
+                # No exact reserved key: route to the cloud action path. Warn on a stray
+                # mir_-prefixed key so a fat-fingered type key fails loudly, not silently.
+                if any(isinstance(k, str) and k.startswith(MIR_RESERVED_PREFIX) for k in args):
+                    logger.warning(
+                        f"runAction step {step.label!r} has {MIR_RESERVED_PREFIX}-prefixed "
+                        f"arg(s) but no {RESERVED_MIR_ARG_TYPE_KEY}; routing to the cloud action "
+                        f"path (typo?)"
+                    )
+                # fall through to flush + passthrough below
 
             # Non-nestable step — flush pending actions first
             flush_actions()

--- a/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/tree_builder.py
@@ -12,12 +12,13 @@
 #     mission tracking (TaskStarted/TaskCompletedNode), robot locking (LockRobotNode) and
 #     per-step timeouts (TimeoutNode) are restored for edge missions. Upstream
 #     dropped the decorator, so only the final task list was reported.
+#   - 2026-06-30: removed the LoggingMissionCompletedNode debug subclass and use the base
+#     MissionCompletedNode directly. It only wrapped mt.completed() in noisy INFO logging
+#     (no behavior change).
 
 """Tree builder for MiR missions with compiled native mission steps."""
 
 from __future__ import annotations
-
-import logging
 
 from inorbit_edge_executor.behavior_tree import (
     BehaviorTree,
@@ -27,7 +28,6 @@ from inorbit_edge_executor.behavior_tree import (
     MissionCompletedNode,
     MissionInProgressNode,
     MissionPausedNode,
-    register_accepted_node_types,
 )
 from inorbit_edge_executor.inorbit import MissionStatus
 
@@ -36,24 +36,6 @@ from inorbit_mir_connector.src.mission.behavior_tree import (
     MirMissionAbortedNode,
     MirNodeFromStepBuilder,
 )
-
-logger = logging.getLogger(__name__)
-
-
-class LoggingMissionCompletedNode(MissionCompletedNode):
-    """MissionCompletedNode with debug logging around mt.completed()."""
-
-    async def _execute(self):
-        logger.info(f"MissionCompletedNode: calling mt.completed() for mission {self.mt.id}")
-        try:
-            result = await self.mt.completed()
-            logger.info(f"MissionCompletedNode: mt.completed() returned {result}")
-        except Exception as e:
-            logger.error(f"MissionCompletedNode: mt.completed() raised {e}")
-            raise
-
-
-register_accepted_node_types([LoggingMissionCompletedNode])
 
 
 class MirTreeBuilder(DefaultTreeBuilder):
@@ -83,7 +65,7 @@ class MirTreeBuilder(DefaultTreeBuilder):
             if node:
                 tree.add_node(node)
 
-        tree.add_node(LoggingMissionCompletedNode(context, label="mission completed"))
+        tree.add_node(MissionCompletedNode(context, label="mission completed"))
 
         # Error handling
         on_error = BehaviorTreeSequential(label="error handlers")

--- a/mir_connector/inorbit_mir_connector/src/mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_exec.py
@@ -272,10 +272,12 @@ class MirMissionExecutor:
                 execution_status_details=f"Invalid JSON: {e}",
             )
         except Exception as e:
-            self.logger.error(f"Failed to execute mission: {e}")
+            # TranslationException is bare (empty str); real reason is on the chained cause.
+            detail = str(e) or str(e.__cause__ or "") or str(e.__context__ or "") or repr(e)
+            self.logger.error(f"Failed to execute mission: {detail}")
             options["result_function"](
                 CommandResultCode.FAILURE,
-                execution_status_details=str(e),
+                execution_status_details=detail,
             )
 
     async def _handle_cancel_mission(self, script_args: dict, options: dict) -> None:

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -791,3 +791,30 @@ def test_shutdown_handler_is_reentrant_safe_and_swallows_errors():
     # Repeated interrupt while shutting down: ignored, stop() not called again.
     handler()
     connector.stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execution_loop_logs_transient_mission_error_without_traceback(
+    connector_with_mission_tracking, caplog
+):
+    """A transient MiR connection drop while reporting a mission must log one
+    concise line, not a full httpx traceback (which spammed the logs)."""
+    connector = connector_with_mission_tracking
+    connector.robot._status = {"robot_model": "MiR100"}
+    connector.publish_pose = MagicMock()
+    connector.publish_odometry = MagicMock()
+    connector.publish_key_values = MagicMock()
+    connector.publish_system_stats = MagicMock()
+    connector.mission_tracking.report_mission = AsyncMock(
+        side_effect=httpx.RemoteProtocolError("Server disconnected without sending a response")
+    )
+
+    with caplog.at_level("WARNING"):
+        # Must not raise despite the failing report.
+        await connector._execution_loop()
+
+    records = [r for r in caplog.records if "Error reporting mission" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].levelname == "WARNING"
+    assert records[0].exc_info is None  # concise, no traceback
+    assert "Server disconnected" in records[0].getMessage()

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 import pytest
 from inorbit_edge_executor.datatypes import MissionRuntimeSharedMemory
 
+from inorbit_mir_connector.src.mir_api import MirApiV2
 from inorbit_mir_connector.src.mission.behavior_tree import (
     CleanupMirMissionNode,
     CreateMirNativeMissionNode,
@@ -209,6 +210,40 @@ async def test_docking_without_offset_raises_and_does_not_queue():
 
     assert api.queued == []
     assert ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_create_failure_surfaces_mir_reason_in_error_message(httpx_mock):
+    """A MiR 4xx body (the reason it rejected the request) must reach the
+    operator-facing abort, not just the logs.
+
+    Drives the real MirApiV2 so the full chain is exercised: create_mission
+    400s -> mir_api_base._request augments the HTTPStatusError with the body ->
+    CreateMirNativeMissionNode surfaces ``{e}`` into MIR_ERROR_MESSAGE. A bare
+    HTTPStatusError would put only the status line ("400 Bad Request") there.
+    """
+    api = MirApiV2(
+        mir_host_address="example.com",
+        mir_host_port=8080,
+        mir_use_ssl=False,
+        mir_username="user",
+        mir_password="pass",
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{api.mir_api_base_url}/missions",
+        status_code=400,
+        json={"error": {"message": "action parameter 'time' is invalid"}},
+    )
+    node, ctx = _build_node(
+        api, [MirAction(label="Wait", action_type="wait", parameters={"time": "nope"})]
+    )
+
+    with pytest.raises(RuntimeError):
+        await node._execute()
+
+    error_msg = ctx.shared_memory.get(SharedMemoryKeys.MIR_ERROR_MESSAGE)
+    assert "action parameter 'time' is invalid" in error_msg
 
 
 def _build_abort_context(api, queue_id):

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_native_mission_node.py
@@ -69,6 +69,7 @@ class FakeMirApi:
                 "priority": priority,
             }
         )
+        return {"guid": f"action-guid-{priority}"}
 
     async def queue_mission(self, mission_guid):
         self.queued.append(mission_guid)

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_exec.py
@@ -12,13 +12,19 @@ started — only the synchronous override hooks are exercised.
 
 from __future__ import annotations
 
+import json
+import logging
+import unittest.mock as mock
 from types import SimpleNamespace
 
+import pytest
+from inorbit_connector.commands import CommandResultCode
 from inorbit_edge_executor.datatypes import (
     MissionDefinition,
     MissionStepPoseWaypoint,
     Pose,
 )
+from inorbit_edge_executor.exceptions import TranslationException
 from inorbit_edge_executor.mission import Mission
 
 from inorbit_mir_connector.src.mission.behavior_tree import (
@@ -29,7 +35,7 @@ from inorbit_mir_connector.src.mission.datatypes import (
     MissionStepExecuteMirNativeMission,
 )
 from inorbit_mir_connector.src.mission.tree_builder import MirTreeBuilder
-from inorbit_mir_connector.src.mission_exec import MirWorkerPool
+from inorbit_mir_connector.src.mission_exec import MirMissionExecutor, MirWorkerPool
 
 ROBOT_ID = "mir-1"
 
@@ -109,3 +115,30 @@ def test_deserialize_mission_round_trips():
 
     assert isinstance(restored, MirInOrbitMission)
     assert isinstance(restored.definition.steps[0], MissionStepExecuteMirNativeMission)
+
+
+@pytest.mark.asyncio
+async def test_translate_failure_surfaces_reason():
+    """A swallowed translate-time error reaches result_function, not an empty detail."""
+    reason = "runAction step 'x': 'if' is a control-flow action"
+
+    async def fail(*_a, **_kw):
+        try:
+            raise ValueError(reason)
+        except ValueError:
+            raise TranslationException()  # bare, chains the ValueError on __context__
+
+    executor = MirMissionExecutor.__new__(MirMissionExecutor)
+    executor.logger = logging.getLogger("test")
+    executor.robot_id = ROBOT_ID
+    executor._worker_pool = SimpleNamespace(submit_work=fail)
+
+    result_function = mock.MagicMock()
+    await executor._handle_execute_mission_action(
+        {"missionId": "m1", "missionDefinition": json.dumps({"steps": []})},
+        {"result_function": result_function},
+    )
+
+    result_function.assert_called_once()
+    assert result_function.call_args.args[0] == CommandResultCode.FAILURE
+    assert reason in result_function.call_args.kwargs["execution_status_details"]

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_resume.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_resume.py
@@ -268,3 +268,23 @@ async def test_resume_skips_create_node_no_duplicate_mission():
     assert api2.queued == []
     # Wait node resumed from the restored queue id and saw it complete.
     assert api2.polled == [QUEUE_ID]
+
+
+def test_bounded_native_step_dump_roundtrips():
+    """A native step carrying timeoutSecs dumps with aliases so resume re-validates it."""
+    step = MissionStepExecuteMirNativeMission(
+        label="grp",
+        actions=[MirWaypoint(label="wp", x=1.0, y=2.0, orientation=0.0)],
+        robot_id=ROBOT_ID,
+        timeoutSecs=25.0,
+    )
+    sm = MissionRuntimeSharedMemory()
+    ctx = MirBehaviorTreeBuilderContext(
+        mir_api=mock.MagicMock(), missions_group_id="grp", firmware_version="v3", connector_type="mir"
+    )
+    ctx.shared_memory = sm
+    node = CreateMirNativeMissionNode(ctx, step, label="create")
+
+    dumped = node.dump_object()["step"]
+    assert "timeoutSecs" in dumped and "timeout_secs" not in dumped
+    MissionStepExecuteMirNativeMission.model_validate(dumped)  # raised ValidationError pre-fix

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_resume.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_resume.py
@@ -197,7 +197,7 @@ class _RecordingMirApi:
         self.created.append(guid)
 
     async def add_action_to_mission(self, action_type, mission_id, parameters, priority):
-        pass
+        return {"guid": f"action-guid-{priority}"}
 
     async def queue_mission(self, mission_guid):
         self.queued.append(mission_guid)

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_resume.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_resume.py
@@ -280,7 +280,10 @@ def test_bounded_native_step_dump_roundtrips():
     )
     sm = MissionRuntimeSharedMemory()
     ctx = MirBehaviorTreeBuilderContext(
-        mir_api=mock.MagicMock(), missions_group_id="grp", firmware_version="v3", connector_type="mir"
+        mir_api=mock.MagicMock(),
+        missions_group_id="grp",
+        firmware_version="v3",
+        connector_type="mir",
     )
     ctx.shared_memory = sm
     node = CreateMirNativeMissionNode(ctx, step, label="create")

--- a/mir_connector/inorbit_mir_connector/tests/test_native_task_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_native_task_tracking.py
@@ -6,9 +6,12 @@
 
 After grouping, a native MiR mission carries several InOrbit tasks (action_task_ids,
 parallel to its actions). The SDK step decorator no longer emits TaskStarted/CompletedNode
-for them, so the completion node marks each task as its MiR action runs, using the
-executed-action count from GET /mission_queue/{id}/actions (the same signal robot-side
-mission tracking uses). These tests pin that marking.
+for them, so the completion node marks each task as its MiR action runs. It pairs each task
+with the guid captured when the action was created, then per poll resolves each queued
+action's action_id (== that guid) and finished timestamp via the mission-queue detail
+endpoint. Matching by guid -- not list length -- ignores a load_mission's inlined
+sub-actions (foreign guids), so nested missions no longer over-complete. These tests pin
+that marking.
 """
 
 from __future__ import annotations
@@ -35,20 +38,37 @@ ROBOT_ID = "mir-1"
 QUEUE_ID = 42
 
 
-class _ProgressMirApi:
-    """Reports ``action_count`` executed actions and a fixed queue-entry state."""
+def _entry(int_id, action_id, finished=False):
+    """One executed mission-queue action, as the detail endpoint reports it."""
+    return {"id": int_id, "action_id": action_id, "finished": "ts" if finished else None}
 
-    def __init__(self, action_count=0, state="Executing"):
-        self.action_count = action_count
+
+class _ProgressMirApi:
+    """Models the queue LIST (``[{id, url}]``) + DETAIL (``{action_id, finished}``)
+    endpoints plus the queue-entry state, driven by an ``executed`` list the test advances."""
+
+    def __init__(self, executed=None, state="Executing"):
+        self.executed = executed or []
         self.state = state
-        self.action_polls = 0
+        self.list_polls = 0
+        self.detail_polls = 0
 
     async def get_mission_queue_entry(self, queue_id):
         return {"state": self.state}
 
     async def get_mission_queue_actions(self, queue_id):
-        self.action_polls += 1
-        return [{"id": i} for i in range(self.action_count)]
+        self.list_polls += 1
+        return [
+            {"id": e["id"], "url": f"/mission_queue/{queue_id}/actions/{e['id']}"}
+            for e in self.executed
+        ]
+
+    async def get_mission_queue_action(self, queue_id, action_int_id):
+        self.detail_polls += 1
+        for e in self.executed:
+            if e["id"] == action_int_id:
+                return {"id": e["id"], "action_id": e["action_id"], "finished": e["finished"]}
+        raise KeyError(action_int_id)
 
 
 def _mission_with_tasks(task_ids):
@@ -64,13 +84,15 @@ def _mission_with_tasks(task_ids):
     )
 
 
-def _wait_node(api, action_task_ids, mission):
+def _wait_node(api, action_task_ids, mission, action_guids):
     sm = MissionRuntimeSharedMemory()
     sm.add(SharedMemoryKeys.MIR_QUEUE_ID, None)
     sm.add(SharedMemoryKeys.MIR_MISSION_GUID, None)
     sm.add(SharedMemoryKeys.MIR_ERROR_MESSAGE, None)
+    sm.add(SharedMemoryKeys.MIR_ACTION_GUIDS, None)
     sm.freeze()
     sm.set(SharedMemoryKeys.MIR_QUEUE_ID, QUEUE_ID)
+    sm.set(SharedMemoryKeys.MIR_ACTION_GUIDS, action_guids)
     ctx = MirBehaviorTreeBuilderContext(
         mir_api=api,
         missions_group_id="grp",
@@ -91,19 +113,23 @@ def _status(mission, task_id):
 @pytest.mark.asyncio
 async def test_marks_each_task_as_its_action_progresses():
     ids = ["t1", None, "t2"]
+    guids = ["g0", "g1", "g2"]
     mission = _mission_with_tasks(ids)
     api = _ProgressMirApi()
-    node, ctx = _wait_node(api, ids, mission)
+    node, ctx = _wait_node(api, ids, mission, guids)
 
-    api.action_count = 1  # action 0 (t1) running
+    api.executed = [_entry(0, "g0")]  # action g0 (t1) running
     await node._report_progress(QUEUE_ID)
     assert _status(mission, "t1") == (True, False)
 
-    api.action_count = 2  # action 0 finished, action 1 (no task) running
+    api.executed = [
+        _entry(0, "g0", finished=True),
+        _entry(1, "g1"),
+    ]  # g0 done, g1 (no task) running
     await node._report_progress(QUEUE_ID)
     assert _status(mission, "t1") == (False, True)
 
-    api.action_count = 3  # action 2 (t2) running
+    api.executed += [_entry(2, "g2")]  # g2 (t2) running
     await node._report_progress(QUEUE_ID)
     assert _status(mission, "t2") == (True, False)
 
@@ -115,26 +141,89 @@ async def test_marks_each_task_as_its_action_progresses():
 @pytest.mark.asyncio
 async def test_done_marks_all_remaining_tasks_completed():
     ids = ["t1", "t2"]
+    guids = ["g0", "g1"]
     mission = _mission_with_tasks(ids)
-    api = _ProgressMirApi(action_count=1, state="Done")
-    node, ctx = _wait_node(api, ids, mission)
+    api = _ProgressMirApi(executed=[_entry(0, "g0")], state="Done")
+    node, ctx = _wait_node(api, ids, mission, guids)
 
-    await node._execute()  # Done on the first poll, before the count reaches both actions
+    await node._execute()  # Done before g1 ever appears in the queue
 
     assert _status(mission, "t1") == (False, True)
     assert _status(mission, "t2") == (False, True)
-    assert api.action_polls >= 1
+    assert api.list_polls >= 1
     ctx.mt.report_tasks.assert_awaited()
 
 
 @pytest.mark.asyncio
 async def test_untracked_group_does_not_poll_actions():
     mission = _mission_with_tasks([])
-    api = _ProgressMirApi(action_count=0, state="Done")
-    node, ctx = _wait_node(api, [None, None], mission)
+    api = _ProgressMirApi(executed=[_entry(0, "g0")], state="Done")
+    node, ctx = _wait_node(api, [None, None], mission, ["g0", "g1"])
 
     await node._execute()
 
-    # No tasks -> the per-action progress endpoint is never polled, nothing reported.
-    assert api.action_polls == 0
+    # No tasks -> the per-action progress endpoints are never polled, nothing reported.
+    assert api.list_polls == 0
+    assert api.detail_polls == 0
     ctx.mt.report_tasks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_nested_mission_ignores_foreign_subactions():
+    # g1 is a load_mission; at runtime its sub-mission's actions inline with FOREIGN guids.
+    ids = ["t1", "t2", "t3"]
+    guids = ["g0", "g1", "g2"]
+    mission = _mission_with_tasks(ids)
+    api = _ProgressMirApi()
+    node, _ = _wait_node(api, ids, mission, guids)
+
+    # Robot on the first action only: t3 must NOT complete (the old count bug did).
+    api.executed = [_entry(0, "g0")]
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t1") == (True, False)
+    assert _status(mission, "t3") == (False, False)
+
+    # load_mission (g1) running with its sub-actions inlined as foreign guids fa/fb.
+    api.executed = [
+        _entry(0, "g0", finished=True),
+        _entry(1, "g1"),
+        _entry(2, "fa", finished=True),
+        _entry(3, "fb"),
+    ]
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t1") == (False, True)
+    assert _status(mission, "t2") == (True, False)  # load_mission's own task, from its own entry
+    assert _status(mission, "t3") == (False, False)  # foreign sub-actions did not advance t3
+
+    # load_mission done, real action g2 starts -> only now does t3 advance.
+    api.executed = [
+        _entry(0, "g0", finished=True),
+        _entry(1, "g1", finished=True),
+        _entry(2, "fa", finished=True),
+        _entry(3, "fb", finished=True),
+        _entry(4, "g2"),
+    ]
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t2") == (False, True)
+    assert _status(mission, "t3") == (True, False)
+
+
+@pytest.mark.asyncio
+async def test_no_guid_match_falls_back_to_finish_at_done():
+    # Fail-safe: if no queued action_id matches our guids, nothing is marked mid-flight,
+    # a single warning fires, and _finish_tasks still completes everything at Done.
+    ids = ["t1", "t2"]
+    mission = _mission_with_tasks(ids)
+    api = _ProgressMirApi(executed=[_entry(0, "x0"), _entry(1, "x1")])
+    node, ctx = _wait_node(api, ids, mission, ["g0", "g1"])
+
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t1") == (False, False)
+    assert _status(mission, "t2") == (False, False)
+    assert node._warned_no_match is True
+    ctx.mt.report_tasks.assert_not_awaited()
+
+    await node._finish_tasks()
+    assert _status(mission, "t1") == (False, True)
+    assert _status(mission, "t2") == (False, True)
+    ctx.mt.report_tasks.assert_awaited()

--- a/mir_connector/inorbit_mir_connector/tests/test_native_task_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_native_task_tracking.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Per-task tracking inside WaitForMirMissionCompletionNode.
+
+After grouping, a native MiR mission carries several InOrbit tasks (action_task_ids,
+parallel to its actions). The SDK step decorator no longer emits TaskStarted/CompletedNode
+for them, so the completion node marks each task as its MiR action runs, using the
+executed-action count from GET /mission_queue/{id}/actions (the same signal robot-side
+mission tracking uses). These tests pin that marking.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from inorbit_edge_executor.datatypes import (
+    MissionDefinition,
+    MissionRuntimeSharedMemory,
+    MissionStepPoseWaypoint,
+    MissionTask,
+    Pose,
+)
+from inorbit_edge_executor.mission import Mission
+
+from inorbit_mir_connector.src.mission.behavior_tree import (
+    MirBehaviorTreeBuilderContext,
+    SharedMemoryKeys,
+    WaitForMirMissionCompletionNode,
+)
+
+ROBOT_ID = "mir-1"
+QUEUE_ID = 42
+
+
+class _ProgressMirApi:
+    """Reports ``action_count`` executed actions and a fixed queue-entry state."""
+
+    def __init__(self, action_count=0, state="Executing"):
+        self.action_count = action_count
+        self.state = state
+        self.action_polls = 0
+
+    async def get_mission_queue_entry(self, queue_id):
+        return {"state": self.state}
+
+    async def get_mission_queue_actions(self, queue_id):
+        self.action_polls += 1
+        return [{"id": i} for i in range(self.action_count)]
+
+
+def _mission_with_tasks(task_ids):
+    tasks = [MissionTask(taskId=t, label=t) for t in task_ids if t is not None]
+    return Mission(
+        id="m1",
+        robot_id=ROBOT_ID,
+        definition=MissionDefinition(
+            label="t",
+            steps=[MissionStepPoseWaypoint(waypoint=Pose(x=0, y=0, theta=0), label="wp")],
+        ),
+        tasks_list=tasks,
+    )
+
+
+def _wait_node(api, action_task_ids, mission):
+    sm = MissionRuntimeSharedMemory()
+    sm.add(SharedMemoryKeys.MIR_QUEUE_ID, None)
+    sm.add(SharedMemoryKeys.MIR_MISSION_GUID, None)
+    sm.add(SharedMemoryKeys.MIR_ERROR_MESSAGE, None)
+    sm.freeze()
+    sm.set(SharedMemoryKeys.MIR_QUEUE_ID, QUEUE_ID)
+    ctx = MirBehaviorTreeBuilderContext(
+        mir_api=api,
+        missions_group_id="grp",
+        firmware_version="v3",
+        connector_type="mir",
+        mission=mission,
+        mt=AsyncMock(),
+    )
+    ctx.shared_memory = sm
+    return WaitForMirMissionCompletionNode(ctx, action_task_ids=action_task_ids), ctx
+
+
+def _status(mission, task_id):
+    task = mission.find_task(task_id)
+    return (task.in_progress, task.completed)
+
+
+@pytest.mark.asyncio
+async def test_marks_each_task_as_its_action_progresses():
+    ids = ["t1", None, "t2"]
+    mission = _mission_with_tasks(ids)
+    api = _ProgressMirApi()
+    node, ctx = _wait_node(api, ids, mission)
+
+    api.action_count = 1  # action 0 (t1) running
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t1") == (True, False)
+
+    api.action_count = 2  # action 0 finished, action 1 (no task) running
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t1") == (False, True)
+
+    api.action_count = 3  # action 2 (t2) running
+    await node._report_progress(QUEUE_ID)
+    assert _status(mission, "t2") == (True, False)
+
+    await node._finish_tasks()
+    assert _status(mission, "t2") == (False, True)
+    ctx.mt.report_tasks.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_done_marks_all_remaining_tasks_completed():
+    ids = ["t1", "t2"]
+    mission = _mission_with_tasks(ids)
+    api = _ProgressMirApi(action_count=1, state="Done")
+    node, ctx = _wait_node(api, ids, mission)
+
+    await node._execute()  # Done on the first poll, before the count reaches both actions
+
+    assert _status(mission, "t1") == (False, True)
+    assert _status(mission, "t2") == (False, True)
+    assert api.action_polls >= 1
+    ctx.mt.report_tasks.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_untracked_group_does_not_poll_actions():
+    mission = _mission_with_tasks([])
+    api = _ProgressMirApi(action_count=0, state="Done")
+    node, ctx = _wait_node(api, [None, None], mission)
+
+    await node._execute()
+
+    # No tasks -> the per-action progress endpoint is never polled, nothing reported.
+    assert api.action_polls == 0
+    ctx.mt.report_tasks.assert_not_awaited()

--- a/mir_connector/inorbit_mir_connector/tests/test_native_timeout.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_native_timeout.py
@@ -102,15 +102,14 @@ class TestNativeMissionTimeout:
         assert isinstance(step, MissionStepExecuteMirNativeMission)
         assert step.timeout_secs is None
 
-    def test_task_boundary_split_computes_per_group(self):
-        # [wp(10, completeTask="t1"), wp(20)] -> first native step timeout 10,
-        # second native step unbounded (no timeout aggregated across the split).
+    def test_task_on_step_no_longer_splits_timeout(self):
+        # [wp(10, completeTask="t1"), wp(20)] now groups into one native step (a task no
+        # longer flushes the group), so the timeout is the sum of both bounded steps.
         m = _mission([_wp(10, complete_task="t1"), _wp(20)])
         result = InOrbitToMirTranslator.translate(m)
 
-        assert len(result.definition.steps) == 2
-        first, second = result.definition.steps
-        assert isinstance(first, MissionStepExecuteMirNativeMission)
-        assert first.timeout_secs == 10
-        assert isinstance(second, MissionStepExecuteMirNativeMission)
-        assert second.timeout_secs == 20
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert step.timeout_secs == 30
+        assert step.action_task_ids == ["t1", None]

--- a/mir_connector/inorbit_mir_connector/tests/test_per_task_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_per_task_tracking.py
@@ -33,11 +33,13 @@ from inorbit_edge_executor.datatypes import (
     MissionRuntimeSharedMemory,
     MissionStepPoseWaypoint,
     MissionStepRunAction,
+    MissionStepSetData,
     MissionStepWait,
     Pose,
 )
 from inorbit_edge_executor.mission import Mission
 
+from inorbit_mir_connector.src.mission.behavior_tree import WaitForMirMissionCompletionNode
 from inorbit_mir_connector.src.mission.datatypes import MissionStepExecuteMirNativeMission
 from inorbit_mir_connector.src.mission.translator import InOrbitToMirTranslator
 from inorbit_mir_connector.src.mission_exec import MirWorkerPool
@@ -84,24 +86,28 @@ class TestTranslatorPreservesCompleteTask:
         assert len(result.definition.steps) == 1
         step = result.definition.steps[0]
         assert isinstance(step, MissionStepExecuteMirNativeMission)
-        assert step.complete_task == "task-1"
+        # The native step rides no single task; the task is carried per-action instead.
+        assert step.complete_task is None
+        assert step.action_task_ids == ["task-1"]
         # The task must reach the mission's tasks_list (what InOrbit displays).
         assert _task_ids(result) == ["task-1"]
 
-    def test_task_boundary_flushes_group(self):
-        # task on a middle waypoint flushes the group at that point.
+    def test_task_on_middle_step_no_longer_splits_group(self):
+        # A task on a middle waypoint no longer flushes the group: all three waypoints
+        # compile into one native step, the task riding the middle action.
         m = _mission([_wp(1, 2), _wp(3, 4, complete_task="t1"), _wp(5, 6)])
         result = InOrbitToMirTranslator.translate(m)
 
-        assert len(result.definition.steps) == 2
-        first, second = result.definition.steps
-        assert isinstance(first, MissionStepExecuteMirNativeMission)
-        assert [type(a).__name__ for a in first.actions] == ["MirWaypoint", "MirWaypoint"]
-        assert first.complete_task == "t1"
-        # trailing waypoint forms its own native group with no task.
-        assert isinstance(second, MissionStepExecuteMirNativeMission)
-        assert len(second.actions) == 1
-        assert second.complete_task is None
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert [type(a).__name__ for a in step.actions] == [
+            "MirWaypoint",
+            "MirWaypoint",
+            "MirWaypoint",
+        ]
+        assert step.complete_task is None
+        assert step.action_task_ids == [None, "t1", None]
         assert _task_ids(result) == ["t1"]
 
     def test_multiple_tasks_each_reported(self):
@@ -113,7 +119,39 @@ class TestTranslatorPreservesCompleteTask:
             ]
         )
         result = InOrbitToMirTranslator.translate(m)
+        # One native step carries both tasks, parallel to its actions.
+        assert len(result.definition.steps) == 1
+        assert result.definition.steps[0].action_task_ids == ["t1", None, "t2"]
         assert _task_ids(result) == ["t1", "t2"]
+
+    def test_production_payload_groups_into_one_native_mission(self):
+        # The reported regression shape: [setData, wp, wp, wait, wp] with a task on each
+        # nestable step. setData passes through; the four nestable steps compile into ONE
+        # native mission carrying all four tasks (parallel to actions).
+        m = _mission(
+            [
+                MissionStepSetData(data={"waypointDistanceTolerance": 1}, label="set"),
+                _wp(1, 2, label="a", complete_task="a"),
+                _wp(3, 4, label="b", complete_task="b"),
+                MissionStepWait(timeoutSecs=5, label="Wait 5 sec", completeTask="Wait 5 sec"),
+                _wp(5, 6, label="c", complete_task="c"),
+            ]
+        )
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 2
+        passthrough, native = result.definition.steps
+        assert isinstance(passthrough, MissionStepSetData)
+        assert isinstance(native, MissionStepExecuteMirNativeMission)
+        assert [type(a).__name__ for a in native.actions] == [
+            "MirWaypoint",
+            "MirWaypoint",
+            "MirAction",
+            "MirWaypoint",
+        ]
+        assert native.complete_task is None
+        assert native.action_task_ids == ["a", "b", "Wait 5 sec", "c"]
+        assert _task_ids(result) == ["a", "b", "Wait 5 sec", "c"]
 
     def test_consecutive_no_task_waypoints_still_group(self):
         # Behaviour unchanged when no step carries complete_task.
@@ -166,10 +204,15 @@ def _build_tree(mission):
     return nodes
 
 
-def test_tree_emits_task_nodes_for_task_bearing_step():
+def test_grouped_task_tracked_by_wait_node_not_decorator():
     nodes = _build_tree(_mission([_wp(1, 2, complete_task="task-1")]))
-    assert any(isinstance(n, TaskStartedNode) for n in nodes)
-    assert any(isinstance(n, TaskCompletedNode) for n in nodes)
+    # Grouping drops the per-step decorator task nodes; the wait node carries the task and
+    # reports it from the native mission's per-action progress instead.
+    assert not any(isinstance(n, TaskStartedNode) for n in nodes)
+    assert not any(isinstance(n, TaskCompletedNode) for n in nodes)
+    wait_nodes = [n for n in nodes if isinstance(n, WaitForMirMissionCompletionNode)]
+    assert len(wait_nodes) == 1
+    assert wait_nodes[0]._action_task_ids == ["task-1"]
     # LockRobotNode is always added by the decorator (no-op unless use_locks).
     assert any(isinstance(n, LockRobotNode) for n in nodes)
 

--- a/mir_connector/inorbit_mir_connector/tests/test_translator.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_translator.py
@@ -10,11 +10,17 @@
 #   - 2026-06-26: rebased import prefix mir_connector.src.* -> inorbit_mir_connector.src.*
 #   - 2026-06-26: added TestOrientationNormalization (orientation wrapped to MiR's
 #     [-180, 180] range; MiR rejects move_to_position outside it with HTTP 400)
+#   - 2026-06-29: native-action routing moved from the NESTABLE_MIR_ACTIONS name-match to the
+#     reserved `mir_actionType` argument key (spec native-mission-action-steps.md, phase 1).
+#     Migrated the 3 name-match tests to drive nesting via arguments.mir_actionType; added
+#     None-gate / bare-action_id passthrough, blank-type error, deny-list, typo/zero-param
+#     warnings, docking auto-resolve handoff, load_mission nesting, and sole/last-step tests.
 
 """Unit tests for InOrbitToMirTranslator."""
 
 from __future__ import annotations
 
+import logging
 import math
 
 import pytest
@@ -34,6 +40,7 @@ from inorbit_mir_connector.src.mission.datatypes import (
     MissionStepExecuteMirNativeMission,
 )
 from inorbit_mir_connector.src.mission.translator import (
+    DENIED_NATIVE_ACTIONS,
     InOrbitToMirTranslator,
     _seconds_to_mir_duration,
 )
@@ -129,7 +136,16 @@ class TestTranslateWaitNested:
 
 class TestTranslateRunActionNestable:
     def test_nestable_action_compiled(self):
-        m = _mission([_pose_wp(1, 2), _run_action("docking", {"marker": "guid-1"})])
+        # action_id is intentionally NOT a MiR action name: routing is now purely by the
+        # reserved mir_actionType key, and the reserved key is excluded from parameters.
+        m = _mission(
+            [
+                _pose_wp(1, 2),
+                _run_action(
+                    "inorbit-action-uuid", {"mir_actionType": "docking", "marker": "guid-1"}
+                ),
+            ]
+        )
         result = InOrbitToMirTranslator.translate(m)
 
         assert len(result.definition.steps) == 1
@@ -141,7 +157,12 @@ class TestTranslateRunActionNestable:
         assert step.actions[1].parameters == {"marker": "guid-1"}
 
     def test_set_footprint_nestable(self):
-        m = _mission([_pose_wp(1, 2), _run_action("set_footprint", {"footprint": "guid-fp"})])
+        m = _mission(
+            [
+                _pose_wp(1, 2),
+                _run_action("x", {"mir_actionType": "set_footprint", "footprint": "guid-fp"}),
+            ]
+        )
         result = InOrbitToMirTranslator.translate(m)
 
         assert len(result.definition.steps) == 1
@@ -177,7 +198,13 @@ class TestTranslateSetDataFlushes:
 
 class TestTranslateActionsOnly:
     def test_actions_only_no_waypoints(self):
-        m = _mission([_run_action("docking"), _wait(10), _run_action("charging")])
+        m = _mission(
+            [
+                _run_action("a", {"mir_actionType": "docking", "marker": "g"}),
+                _wait(10),
+                _run_action("b", {"mir_actionType": "charging", "minimum_percentage": 80}),
+            ]
+        )
         result = InOrbitToMirTranslator.translate(m)
 
         assert len(result.definition.steps) == 1
@@ -221,3 +248,153 @@ class TestWaypointOrientationConversion:
         wp = step.actions[0]
         assert isinstance(wp, MirWaypoint)
         assert wp.orientation == pytest.approx(45.0)
+
+
+class TestMirActionTypeRouting:
+    """Routing is by the reserved ``mir_actionType`` argument key, not the old
+    NESTABLE_MIR_ACTIONS name-match (spec native-mission-action-steps.md sections 3-4)."""
+
+    def test_none_arguments_passes_through(self):
+        # argument-less runAction: arguments defaults to None; the gate must be None-safe.
+        m = _mission([_pose_wp(1, 2), _run_action("docking"), _pose_wp(3, 4)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 3
+        assert isinstance(result.definition.steps[0], MissionStepExecuteMirNativeMission)
+        assert isinstance(result.definition.steps[1], MissionStepRunAction)
+        assert isinstance(result.definition.steps[2], MissionStepExecuteMirNativeMission)
+
+    def test_bare_action_id_no_marker_passes_through(self):
+        # A former-allowlist name with args but no mir_actionType no longer nests
+        # (the allowlist is deleted): it routes to the cloud action path.
+        m = _mission([_pose_wp(1, 2), _run_action("docking", {"marker": "g"}), _pose_wp(3, 4)])
+        result = InOrbitToMirTranslator.translate(m)
+
+        assert len(result.definition.steps) == 3
+        assert isinstance(result.definition.steps[1], MissionStepRunAction)
+
+    @pytest.mark.parametrize("bad_type", ["", "   ", 123, None, True])
+    def test_present_but_blank_type_raises(self, bad_type):
+        m = _mission([_run_action("x", {"mir_actionType": bad_type})])
+        with pytest.raises(ValueError, match="mir_actionType"):
+            InOrbitToMirTranslator.translate(m)
+
+    def test_type_is_stripped(self):
+        m = _mission([_run_action("x", {"mir_actionType": "  sound_stop  "})])
+        result = InOrbitToMirTranslator.translate(m)
+        assert result.definition.steps[0].actions[0].action_type == "sound_stop"
+
+    def test_reserved_key_excluded_from_parameters(self):
+        m = _mission([_run_action("x", {"mir_actionType": "set_io", "module": "guid", "port": 1})])
+        result = InOrbitToMirTranslator.translate(m)
+        action = result.definition.steps[0].actions[0]
+        assert action.action_type == "set_io"
+        assert action.parameters == {"module": "guid", "port": 1}
+        assert "mir_actionType" not in action.parameters
+
+
+class TestMirActionTypeDenyList:
+    """Scope-bearing / control-flow / loop-only types are rejected at translate time,
+    before any robot-side mission exists (spec section 3.1). The translator never calls
+    create_mission, so raising during translate inherently leaves no orphan mission."""
+
+    DENIED = [
+        "if",
+        "while",
+        "loop",
+        "try_catch",
+        "prompt_user",
+        "reduce_protective_fields",
+        "set_reset_io",
+        "set_reset_plc",
+        "break",
+        "continue",
+    ]
+
+    def test_deny_list_membership_is_exactly_the_ten_types(self):
+        # Guards the template-built DENIED_NATIVE_ACTIONS against silently gaining/losing a type.
+        assert set(DENIED_NATIVE_ACTIONS) == set(self.DENIED)
+
+    @pytest.mark.parametrize("action_type", DENIED)
+    def test_denied_type_raises(self, action_type):
+        m = _mission([_run_action("x", {"mir_actionType": action_type})])
+        with pytest.raises(ValueError, match=action_type):
+            InOrbitToMirTranslator.translate(m)
+
+    def test_return_is_allowed(self):
+        # `return` is a valid top-level abort, not denied (spec section 3.1 note).
+        m = _mission([_run_action("x", {"mir_actionType": "return"})])
+        result = InOrbitToMirTranslator.translate(m)
+        assert result.definition.steps[0].actions[0].action_type == "return"
+
+
+class TestMirActionTypeWarnings:
+    def test_mir_prefix_typo_warns_and_passes_through(self, caplog):
+        # A fat-fingered key (mir_actionTYpe) has no exact mir_actionType: route to the
+        # cloud path but warn so it fails loudly instead of silently vanishing.
+        m = _mission([_run_action("x", {"mir_actionTYpe": "docking"})])
+        with caplog.at_level(logging.WARNING):
+            result = InOrbitToMirTranslator.translate(m)
+        assert isinstance(result.definition.steps[0], MissionStepRunAction)
+        assert "mir_actionType" in caplog.text
+
+    def test_zero_parameters_warns(self, caplog):
+        m = _mission([_run_action("x", {"mir_actionType": "sound_stop"})])
+        with caplog.at_level(logging.WARNING):
+            result = InOrbitToMirTranslator.translate(m)
+        action = result.definition.steps[0].actions[0]
+        assert action.action_type == "sound_stop"
+        assert action.parameters == {}
+        assert "sound_stop" in caplog.text
+
+
+class TestMirActionTypeDocking:
+    """docking nests via mir_actionType with the marker preserved, so the downstream
+    resolve_marker_type (tested in test_marker_type.py / test_mir_native_mission_node.py)
+    fills in marker_type. The reserved key must be stripped (spec section 7)."""
+
+    def test_docking_via_mir_action_type_preserves_marker(self):
+        m = _mission([_run_action("x", {"mir_actionType": "docking", "marker": "marker-guid"})])
+        result = InOrbitToMirTranslator.translate(m)
+        action = result.definition.steps[0].actions[0]
+        assert isinstance(action, MirAction)
+        assert action.action_type == "docking"
+        assert action.parameters == {"marker": "marker-guid"}
+
+
+class TestMirActionTypeLoadMission:
+    """A pre-existing MiR mission runs in-flow as a native load_mission action; it needs
+    no special-casing, just the generic marker path (spec section 13)."""
+
+    def test_load_mission_nests(self):
+        m = _mission(
+            [_run_action("x", {"mir_actionType": "load_mission", "mission_id": "child-guid"})]
+        )
+        result = InOrbitToMirTranslator.translate(m)
+        assert len(result.definition.steps) == 1
+        action = result.definition.steps[0].actions[0]
+        assert isinstance(action, MirAction)
+        assert action.action_type == "load_mission"
+        assert action.parameters == {"mission_id": "child-guid"}
+
+
+class TestMirActionTypePositioning:
+    def test_native_action_as_sole_step(self):
+        m = _mission([_run_action("x", {"mir_actionType": "adjust_localization"})])
+        result = InOrbitToMirTranslator.translate(m)
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 1
+        assert step.actions[0].action_type == "adjust_localization"
+
+    def test_native_action_as_last_step_after_waypoint(self):
+        # exercises the trailing flush_actions() after the loop
+        m = _mission([_pose_wp(1, 2), _run_action("x", {"mir_actionType": "adjust_localization"})])
+        result = InOrbitToMirTranslator.translate(m)
+        assert len(result.definition.steps) == 1
+        step = result.definition.steps[0]
+        assert isinstance(step, MissionStepExecuteMirNativeMission)
+        assert len(step.actions) == 2
+        assert isinstance(step.actions[0], MirWaypoint)
+        assert step.actions[1].action_type == "adjust_localization"


### PR DESCRIPTION
## Summary

A mission `runAction` step can now run any action from the MiR robot's catalog (docking, charging, I/O, sound, nested missions, and so on) natively, and a grouped native mission reports each InOrbit task as its action runs. Routing is by a reserved `mir_actionType` argument key (vda5050-connector parity) instead of the old hard-coded action-name allowlist.

## Changes

Routing: `runAction` steps route to a native MiR action by the reserved `mir_actionType` argument key, replacing the `NESTABLE_MIR_ACTIONS` name allowlist (deleted). Every other argument is a MiR action parameter, sent by its parameter id as written; the reserved key is excluded. A present-but-blank type is a hard error; a missing key routes to the cloud action path (with a warning when a stray `mir_`-prefixed key is present). Scope-bearing, control-flow, and loop-only types (`DENIED_NATIVE_ACTIONS`, exactly ten) are rejected at translate time, before any `create_mission`, so no orphan mission is left on the robot.

Per-task tracking: consecutive nestable steps now group into one native mission even when each carries `complete_task`, instead of flushing the group per task. The per-action InOrbit task ids ride on the native step (`action_task_ids`, parallel to its actions). `CreateMirNativeMissionNode` captures the guid each `add_action_to_mission` returns into shared memory (`MIR_ACTION_GUIDS`, ordered parallel to the actions), and `WaitForMirMissionCompletionNode` pairs each guid with its task id, then per poll resolves each queued action's `action_id` (which equals that guid) and `finished` timestamp via `GET /mission_queue/{id}/actions/{int_id}`, marking the paired task in_progress/completed. Matching by guid rather than list length ignores a nested `load_mission`'s inlined sub-actions, whose guids are foreign to the created set, so nested missions no longer over-complete every task on the first action; the `load_mission`'s own task is still marked from its own queue entry. If no queued `action_id` matches the created guids the node logs once and falls back to completing all tasks at mission end. This replaces the per-step `TaskStarted`/`TaskCompletedNode` the SDK decorator can no longer emit once steps are grouped. `CreateMirNativeMissionNode.dump_object` now dumps `by_alias=True` so a bounded/tracked native step round-trips on resume; the guid pairing and per-action cache re-derive from shared memory and live MiR on resume, so re-reporting stays idempotent.

Error surfacing: a MiR 4xx response body is folded into the raised `HTTPStatusError` (still retryable for 5xx/408/429) so the MiR reason reaches the InOrbit failure detail instead of only the logs, and `MirMissionExecutor` falls back to an exception's chained cause when its own message is empty. The unused `LoggingMissionCompletedNode` debug subclass is dropped for the base `MissionCompletedNode` (no behavior change).

Docs: a new README section, "Running MiR Actions in Missions" (parameter value types, how to find action types via `GET /actions`, the rejected-action table, and limitations), plus `cac_examples/native_mission.yaml` with dock/charge, set_io, sound, and load_mission examples.

`translator.py`, `datatypes.py`, `behavior_tree.py`, and `tree_builder.py` are vendored under `src/mission/`; the changes are functional only and recorded in each file's modifications header.

## Testing

New `tests/test_native_task_tracking.py` drives the wait node against faked mission-queue list and detail endpoints, covering flat progression, all-remaining-completed at Done, an untracked group that never polls, a nested mission whose foreign sub-action guids are ignored (no premature completion), and the no-guid-match fail-safe. `TestMirActionType*` suites in `tests/test_translator.py` (reserved-key routing, deny-list is exactly the ten types, blank-type error, reserved-key exclusion, `mir_`-typo warning, zero-parameter warning, docking, `load_mission` nesting, native-action positioning). `tests/test_per_task_tracking.py` updated for the group-not-split behavior. Full suite green (192 passed); black and flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
