### PR TITLE
MiR Connector: remove unused symbols

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -593,11 +593,6 @@ class MirConnector(Connector):
         except Exception:
             self._logger.exception("Error reporting mission")
 
-    def publish_api_error(self):
-        """Publish an error message when the API call fails.
-        This value can be used for setting up status and incidents in InOrbit"""
-        self.publish_key_values(api_connected=False)
-
     async def send_waypoint_over_missions(self, pose):
         """Use the connector's mission group to create a move mission to a designated pose."""
         mission_id = str(uuid.uuid4())
@@ -651,29 +646,6 @@ class MirConnector(Connector):
             priority=1,
         )
         await self.mir_api.queue_mission(mission_id)
-
-    async def _delete_unused_missions(self):
-        """Delete unused mission definitions from the temporary missions group."""
-        if not hasattr(self, "tmp_missions_group_id") or not self.tmp_missions_group_id:
-            self._logger.warning("Cannot delete unused missions: missions group not set up")
-            return
-
-        try:
-            mission_defs = await self.mir_api.get_mission_group_missions(self.tmp_missions_group_id)
-            missions_queue = await self.mir_api.get_missions_queue()
-            # Do not delete definitions of missions that are pending or executing
-            protected_mission_defs = [
-                (await self.mir_api.get_mission(mission["id"]))["mission_id"]
-                for mission in missions_queue
-                if mission["state"] in ["Pending", "Executing"]
-            ]
-            # Delete mission definitions that are not protected
-            for mission_def in mission_defs:
-                mission_id = mission_def["guid"]
-                if mission_id not in protected_mission_defs:
-                    await self.mir_api.delete_mission_definition(mission_id)
-        except Exception as ex:
-            self._logger.error(f"Error deleting unused missions: {ex}")
 
     async def fetch_map(self, frame_id: str) -> MapConfigTemp | None:
         """Fetch a map from the MiR robot for the given frame_id.

--- a/mir_connector/inorbit_mir_connector/src/mission_exec.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_exec.py
@@ -187,10 +187,6 @@ class MirMissionExecutor:
             await self._worker_pool.shutdown()
             self.logger.info("MIR Mission Executor shut down")
 
-    def is_initialized(self) -> bool:
-        """Check if the mission executor is initialized."""
-        return self._initialized
-
     async def has_active_mission(self) -> bool:
         """True if an InOrbit-dispatched mission is currently executing for this robot.
 

--- a/mir_connector/inorbit_mir_connector/src/robot/robot.py
+++ b/mir_connector/inorbit_mir_connector/src/robot/robot.py
@@ -5,8 +5,8 @@ from the MiR robot API.
 
 import asyncio
 import logging
-from typing import Coroutine
 import time
+from typing import Coroutine
 
 from inorbit_mir_connector.src.mir_api.mir_api_base import MirApiBaseClass
 
@@ -41,11 +41,6 @@ class Robot:
         self._backoff_time = 1.0  # Start with 1 second backoff
         self._max_backoff_time = 30.0  # Max 30 seconds backoff
         self._last_error_time = 0
-
-        # Per-loop monotonic timestamps of the last successful REST poll
-        # (status / metrics / diagnostics). Kept as cheap liveness state; a
-        # canonical polling-staleness metric could read it in the future.
-        self._last_polling_success_ts: dict[str, float] = {}
 
     def start(self) -> None:
         """Start the tasks that fetch data from the robot."""
@@ -96,36 +91,30 @@ class Robot:
 
     async def _update_status(self) -> None:
         """Fetch the robot status from the API asynchronously."""
-        loop_name = "status"
         try:
             status = await self._mir_api.get_status()
             self._status = status
             self._handle_success()
-            self._last_polling_success_ts[loop_name] = time.monotonic()
         except Exception as e:
             self._handle_error(e, "robot status fetch")
             # Keep the last known status on error
 
     async def _update_metrics(self) -> None:
         """Fetch robot metrics from the API asynchronously."""
-        loop_name = "metrics"
         try:
             metrics = await self._mir_api.get_metrics()
             self._metrics = metrics
             self._handle_success()
-            self._last_polling_success_ts[loop_name] = time.monotonic()
         except Exception as e:
             self._handle_error(e, "robot metrics fetch")
             # Keep the last known metrics on error
 
     async def _update_diagnostics(self) -> None:
         """Fetch robot diagnostics from the API asynchronously."""
-        loop_name = "diagnostics"
         try:
             diagnostics = await self._mir_api.get_diagnostics()
             self._diagnostics = diagnostics
             self._handle_success()
-            self._last_polling_success_ts[loop_name] = time.monotonic()
         except Exception as e:
             self._handle_error(e, "robot diagnostics fetch")
             # Keep the last known diagnostics on error
@@ -144,11 +133,6 @@ class Robot:
     def diagnostics(self) -> dict:
         """Return the latest robot diagnostics"""
         return self._diagnostics
-
-    @property
-    def grouped_vitals(self) -> dict:
-        """Return the latest grouped vitals data sources"""
-        return self._grouped_vitals
 
     @property
     def api_connected(self) -> bool:

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -672,7 +672,8 @@ async def test_connector_loop_publishes_system_stats(connector_with_mission_trac
 @pytest.mark.asyncio
 async def test_missions_garbage_collector(connector):
     # Missions in the temporary group
-    connector.tmp_missions_group_id = "tmp_group_id"
+    connector.mission_group._missions_group_id = "tmp_group_id"
+    connector.mission_group.mir_api = connector.mir_api
     connector.mir_api.get_mission_group_missions.return_value = [
         {
             "url": "/v2.0.0/missions/72003359-6445-419c-85fb-df5576a9ce2e",
@@ -719,7 +720,7 @@ async def test_missions_garbage_collector(connector):
         },  # Not safe to delete
     }
     connector.mir_api.get_mission.side_effect = lambda id: defs[id]
-    await connector._delete_unused_missions()
+    await connector.mission_group._delete_unused_missions()
     # Only deletes the mission definition of mission with id 1
     # and mission that is not in the queue
     connector.mir_api.delete_mission_definition.assert_any_call(


### PR DESCRIPTION
A dead-code scan (per-file finders plus adversarial per-candidate verification) surfaced five unreachable symbols in connector-owned code. All predate this branch; none were introduced by recent work. Each was confirmed by grep and git archaeology. The two vendored `src/mission/` candidates were left untouched (report-only, upstream-owned).

## Removed

| Symbol (file) | Introduced | Died | How it died |
|---|---|---|---|
| `Robot.grouped_vitals` (robot.py) | #69, 2025-09-18 | same commit (dead on arrival) | Returns `self._grouped_vitals`, which is never assigned; would `AttributeError` if called |
| `MirMissionExecutor.is_initialized` (mission_exec.py) | #61, 2025-09-03 | same commit (dead on arrival) | Never called; init state read internally via `self._initialized` |
| `MirConnector.publish_api_error` (connector.py) | #36, 2025-02-05 | #58, 2025-08-22 | Caller removed by the inorbit-connector v1 execution-loop refactor |
| `MirConnector._delete_unused_missions` (connector.py) | #27, 2024-11-26 | #66, 2025-09-03 | Orphaned when the GC logic was extracted into `TmpMissionsGroupHandler`; the live copy lives in `missions_group.py` |
| `Robot._last_polling_success_ts` + 3 `loop_name` locals (robot.py) | #91, 2026-05-11 | #97, 2026-06-08 | Its reader (the `mir_polling_last_success_age_seconds` OTEL gauge) was deleted by the v3 canonical-metrics migration; the writes were left behind |

Two of these were dead on arrival (added speculatively, never wired to a caller); the other three outlived their consumer, each orphaned by a framework or architecture migration.

## Test

`test_missions_garbage_collector` only ever exercised the deleted connector copy of `_delete_unused_missions`. It is repointed to the live `TmpMissionsGroupHandler`, which had no test of its own, so coverage is preserved and the live garbage-collection path is now covered.

## Not touched (vendored, report-only)

`CleanupMirMissionNode` and `MirBehaviorTreeBuilderContext.connector_type` in `src/mission/` are also unreachable in production, but that package is vendored verbatim from upstream, so they are reported rather than pruned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
