### PR TITLE
Omron FlowCore connector: record upstream HTTP metrics

### DIFF
--- a/omron_flowcore_connector/README.md
+++ b/omron_flowcore_connector/README.md
@@ -80,6 +80,24 @@ The Connector can be run as a containerized application using Docker Compose:
 
 The Docker Compose setup supports environment variable configuration via `config/.env` and allows running multiple connector instances. See `docker/docker-compose.example.yaml` for detailed configuration options.
 
+## Metrics (optional)
+
+The connector can expose Prometheus-format metrics so fleet operators can monitor connector health. Metrics are off by default and add no overhead until enabled.
+
+Enable via the top-level `metrics:` block in your fleet YAML (connector-wide, not per-robot):
+
+```yaml
+metrics:
+  enabled: true
+  bind_host: 0.0.0.0
+  bind_port: 9090
+  discovery_dir: null   # set to a writable dir to use Prometheus file_sd
+```
+
+Then scrape with `curl http://localhost:9090/metrics`.
+
+Exported metrics include connector liveness (`inorbit_connector_up`), per-robot InOrbit session status (`inorbit_connector_session_connected`), execution loop ticks/errors, and the upstream FlowCore API request/error/latency family (`inorbit_connector_upstream_http_*` with `vendor="flowcore"`). All metrics share the `inorbit_connector` wire prefix; the connector type rides on every series as a resource attribute rather than in the metric name.
+
 ## Contributing
 
 Any contribution that you make to this repository will be under the MIT license, as dictated by that [license](https://opensource.org/licenses/MIT).

--- a/omron_flowcore_connector/config/fleet.example.yaml
+++ b/omron_flowcore_connector/config/fleet.example.yaml
@@ -53,3 +53,15 @@ maps:
 # Optional: Environment variables for user scripts
 # env_vars:
 #   MY_VAR: value
+
+# Optional: Prometheus metrics endpoint (off by default). When enabled, the
+# connector serves /metrics for fleet operators to monitor connector health
+# (up, per-robot session status, execution loop ticks/errors and upstream
+# FlowCore API request/error/latency metrics).
+# metrics:
+#   enabled: true
+#   bind_host: 0.0.0.0
+#   bind_port: 9090
+#   # Optional: directory for the Prometheus file_sd discovery file. Set to
+#   # null when the scraper already knows the endpoint.
+#   discovery_dir: /var/run/inorbit-metrics

--- a/omron_flowcore_connector/inorbit_omron_connector/src/metrics.py
+++ b/omron_flowcore_connector/inorbit_omron_connector/src/metrics.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Metrics helpers for the FlowCore connector.
+
+This connector does not declare domain instruments of its own: all metrics
+are recorded on the ``inorbit_connector`` framework's canonical
+upstream-HTTP families from the call sites in ``omron/api_client.py``. This
+module only provides the endpoint normalizer (:func:`api_endpoint`) and the
+:func:`error_kind` mapper feeding those calls. The ARCL TCP client is not
+instrumented (the upstream.http family does not fit raw TCP).
+"""
+
+import httpx
+from inorbit_connector.metrics.http import EndpointMapper
+
+
+def error_kind(exc: BaseException) -> str:
+    """Map an exception to the canonical ``upstream.http`` error_kind enum.
+
+    Bounded set: ``timeout``, ``connect_error``, ``http_4xx``, ``http_5xx``,
+    ``other``. The framework coerces unknown kinds to "other" with a
+    WARNING; mapping here keeps the logs clean.
+    """
+    if isinstance(exc, httpx.TimeoutException):
+        return "timeout"
+    if isinstance(exc, httpx.ConnectError):
+        return "connect_error"
+    if isinstance(exc, httpx.HTTPStatusError):
+        sc = exc.response.status_code
+        if 400 <= sc < 500:
+            return "http_4xx"
+        if 500 <= sc < 600:
+            return "http_5xx"
+    return "other"
+
+
+# Endpoint normalizer for the canonical upstream-HTTP metrics. FlowCore API
+# routes are static, so an explicit prefix table is preferred over
+# PathTemplater. Longest prefix wins; unknown paths collapse to "other" so
+# dynamic IDs never blow up Prometheus cardinality.
+api_endpoint = EndpointMapper(
+    [
+        ("/Robot/UpdatedSince", "robot_updated_since"),
+        ("/DataStoreValueLatest", "data_store_value_latest"),
+        ("/JobRequest", "job_request"),
+        ("/JobCancel", "job_cancel"),
+        ("/Job/Stream", "job_stream"),
+        ("/JobSegment/Stream", "job_segment_stream"),
+        ("/JobSegment/ByJob", "job_segment_by_job"),
+        ("/Job/ByJobId", "job_by_job_id"),
+        ("/Job/ByKey", "job_by_key"),
+        ("/Dropoff", "dropoff"),
+    ]
+)

--- a/omron_flowcore_connector/inorbit_omron_connector/src/omron/api_client.py
+++ b/omron_flowcore_connector/inorbit_omron_connector/src/omron/api_client.py
@@ -5,9 +5,18 @@
 import httpx
 import logging
 import json
+import time
 from typing import List, Dict, Any, Optional, AsyncIterator
+
+from inorbit_connector.metrics.http import (
+    record_upstream_http_error,
+    record_upstream_http_request,
+)
+
+from ..config.models import CONNECTOR_TYPE
+from ..metrics import api_endpoint, error_kind
 from .models import (
-    DataStoreResponse, 
+    DataStoreResponse,
     RobotResponse
 )
 
@@ -41,15 +50,39 @@ class OmronApiClient:
             await self.client.aclose()
             self.client = None
 
-    async def get_fleet_state(self) -> List[RobotResponse]:
-        """Fetches fleet state from /Robot/UpdatedSince."""
+    async def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        """Send one HTTP request and record canonical upstream-HTTP metrics.
+
+        Raises on any failure (transport error or non-2xx); callers keep
+        their existing try/except fallbacks.
+        """
         if not self.client:
             await self.connect()
-        
+        start = time.monotonic()
         try:
-            response = await self.client.get("/Robot/UpdatedSince?sinceTime=0")
-
+            response = await self.client.request(method, url, **kwargs)
             response.raise_for_status()
+        except Exception as e:
+            record_upstream_http_error(
+                vendor=CONNECTOR_TYPE,
+                method=method,
+                endpoint=api_endpoint(url),
+                error_kind=error_kind(e),
+                duration_seconds=time.monotonic() - start,
+            )
+            raise
+        record_upstream_http_request(
+            vendor=CONNECTOR_TYPE,
+            method=method,
+            endpoint=api_endpoint(url),
+            duration_seconds=time.monotonic() - start,
+        )
+        return response
+
+    async def get_fleet_state(self) -> List[RobotResponse]:
+        """Fetches fleet state from /Robot/UpdatedSince."""
+        try:
+            response = await self._request("GET", "/Robot/UpdatedSince?sinceTime=0")
             data = response.json()
             return [RobotResponse(**r) for r in data]
         except Exception as e:
@@ -58,9 +91,6 @@ class OmronApiClient:
 
     async def get_data_store_value(self, key: str, robot_id: str) -> List[DataStoreResponse]:
         """Fetches data store values for a specific key."""
-        if not self.client:
-            await self.connect()
-        
         mappedKey = {
             "StateOfCharge": "BatteryStateOfCharge",
             "PoseX": "RobotX",
@@ -72,9 +102,7 @@ class OmronApiClient:
         try:
             # The endpoint structure based on the curl: /DataStoreValueLatest/{key}
             url = f"/DataStoreValueLatest/{mappedKey[key]}:{robot_id}"
-            response = await self.client.get(url)
-
-            response.raise_for_status()
+            response = await self._request("GET", url)
             data = response.json()
             
             # If robot_id is not '*', we might need to filter the results
@@ -89,24 +117,16 @@ class OmronApiClient:
             return []
 
     async def create_job(self, job_request: Dict[str, Any]) -> bool:
-        if not self.client:
-            await self.connect()
-        
         try:
-            response = await self.client.post("/JobRequest", json=job_request)
-            response.raise_for_status()
+            await self._request("POST", "/JobRequest", json=job_request)
             return True
         except Exception as e:
             LOGGER.error(f"Error creating job: {e}")
             return False
 
     async def stop(self, job_cancel: Dict[str, Any]) -> bool:
-        if not self.client:
-            await self.connect()
-        
         try:
-            response = await self.client.post("/JobCancel", json=job_cancel)
-            response.raise_for_status()
+            await self._request("POST", "/JobCancel", json=job_cancel)
             return True
         except Exception as e:
             LOGGER.error(f"Error canceling job: {e}")
@@ -145,9 +165,23 @@ class OmronApiClient:
                         
         except httpx.HTTPStatusError as e:
             LOGGER.error(f"HTTP error in job stream: {e}")
+            record_upstream_http_error(
+                vendor=CONNECTOR_TYPE,
+                method="GET",
+                endpoint=api_endpoint("/Job/Stream"),
+                error_kind=error_kind(e),
+                duration_seconds=0.0,
+            )
             raise
         except Exception as e:
             LOGGER.error(f"Error in job stream: {e}")
+            record_upstream_http_error(
+                vendor=CONNECTOR_TYPE,
+                method="GET",
+                endpoint=api_endpoint("/Job/Stream"),
+                error_kind=error_kind(e),
+                duration_seconds=0.0,
+            )
             raise
 
     async def get_job_segment_stream(self) -> AsyncIterator[Dict[str, Any]]:
@@ -183,31 +217,37 @@ class OmronApiClient:
                         
         except httpx.HTTPStatusError as e:
             LOGGER.error(f"HTTP error in job segment stream: {e}")
+            record_upstream_http_error(
+                vendor=CONNECTOR_TYPE,
+                method="GET",
+                endpoint=api_endpoint("/JobSegment/Stream"),
+                error_kind=error_kind(e),
+                duration_seconds=0.0,
+            )
             raise
         except Exception as e:
             LOGGER.error(f"Error in job segment stream: {e}")
+            record_upstream_http_error(
+                vendor=CONNECTOR_TYPE,
+                method="GET",
+                endpoint=api_endpoint("/JobSegment/Stream"),
+                error_kind=error_kind(e),
+                duration_seconds=0.0,
+            )
             raise
 
     async def get_job_segment_list(self, job_namekey: str) -> List[Dict[str, Any]]:
-        if not self.client:
-            await self.connect()
-        
         try:
-            response = await self.client.get(f"/JobSegment/ByJob/{job_namekey}")
-            response.raise_for_status()
+            response = await self._request("GET", f"/JobSegment/ByJob/{job_namekey}")
             data = response.json()
             return data
         except Exception as e:
             LOGGER.error(f"Error fetching fleet state: {e}")
             return []
-    
+
     async def get_job_details_by_job_id(self, job_id: str) -> Optional[Dict[str, Any]]:
-        if not self.client:
-            await self.connect()
-        
         try:
-            response = await self.client.get(f"/Job/ByJobId/{job_id}")
-            response.raise_for_status()
+            response = await self._request("GET", f"/Job/ByJobId/{job_id}")
             data = response.json()
             return data[0] if data and len(data) > 0 else None
         except Exception as e:
@@ -215,12 +255,8 @@ class OmronApiClient:
             return None
 
     async def get_job_details_by_namekey(self, job_namekey: str) -> Optional[Dict[str, Any]]:
-        if not self.client:
-            await self.connect()
-        
         try:
-            response = await self.client.get(f"/Job/ByKey/{job_namekey}")
-            response.raise_for_status()
+            response = await self._request("GET", f"/Job/ByKey/{job_namekey}")
             data = response.json()
             return data
         except Exception as e:
@@ -228,12 +264,8 @@ class OmronApiClient:
             return None
 
     async def create_dropoff(self, dropoff_request: Dict[str, Any]) -> bool:
-        if not self.client:
-            await self.connect()
-        
         try:
-            response = await self.client.post("/Dropoff", json=dropoff_request)
-            response.raise_for_status()
+            await self._request("POST", "/Dropoff", json=dropoff_request)
             return True
         except Exception as e:
             LOGGER.error(f"Error creating dropoff job: {e}")

--- a/omron_flowcore_connector/tests/test_api_client_metrics.py
+++ b/omron_flowcore_connector/tests/test_api_client_metrics.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Metrics recording behavior of OmronApiClient._request."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from inorbit_omron_connector.src.omron.api_client import OmronApiClient
+
+
+def _client() -> OmronApiClient:
+    config = SimpleNamespace(
+        url="https://flowcore.example.com",
+        username="user",
+        password="pass",
+        verify_ssl=False,
+    )
+    api = OmronApiClient(config)
+    api.client = MagicMock(spec=httpx.AsyncClient)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_request_success_records_request_metric():
+    api = _client()
+    response = httpx.Response(200, request=httpx.Request("GET", "https://x/Robot/UpdatedSince"))
+    api.client.request = AsyncMock(return_value=response)
+
+    with patch(
+        "inorbit_omron_connector.src.omron.api_client.record_upstream_http_request"
+    ) as record:
+        result = await api._request("GET", "/Robot/UpdatedSince?sinceTime=0")
+
+    assert result is response
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["vendor"] == "flowcore"
+    assert kwargs["method"] == "GET"
+    assert kwargs["endpoint"] == "robot_updated_since"
+    assert kwargs["duration_seconds"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_request_http_error_records_error_metric_and_raises():
+    api = _client()
+    response = httpx.Response(500, request=httpx.Request("POST", "https://x/JobRequest"))
+    api.client.request = AsyncMock(return_value=response)
+
+    with patch(
+        "inorbit_omron_connector.src.omron.api_client.record_upstream_http_error"
+    ) as record:
+        with pytest.raises(httpx.HTTPStatusError):
+            await api._request("POST", "/JobRequest", json={})
+
+    record.assert_called_once()
+    kwargs = record.call_args.kwargs
+    assert kwargs["vendor"] == "flowcore"
+    assert kwargs["method"] == "POST"
+    assert kwargs["endpoint"] == "job_request"
+    assert kwargs["error_kind"] == "http_5xx"
+
+
+@pytest.mark.asyncio
+async def test_request_timeout_records_error_metric_and_raises():
+    api = _client()
+    api.client.request = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+
+    with patch(
+        "inorbit_omron_connector.src.omron.api_client.record_upstream_http_error"
+    ) as record:
+        with pytest.raises(httpx.ReadTimeout):
+            await api._request("GET", "/JobCancel")
+
+    assert record.call_args.kwargs["error_kind"] == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_public_method_keeps_fallback_on_error():
+    """get_fleet_state still swallows errors and returns [] (behavior unchanged)."""
+    api = _client()
+    api.client.request = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+    with patch("inorbit_omron_connector.src.omron.api_client.record_upstream_http_error"):
+        assert await api.get_fleet_state() == []

--- a/omron_flowcore_connector/tests/test_metrics.py
+++ b/omron_flowcore_connector/tests/test_metrics.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+"""Tests for the upstream-HTTP metrics helpers."""
+
+import httpx
+import pytest
+
+from inorbit_omron_connector.src.metrics import api_endpoint, error_kind
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/Robot/UpdatedSince?sinceTime=0", "robot_updated_since"),
+        ("/DataStoreValueLatest/BatteryStateOfCharge:Robot1", "data_store_value_latest"),
+        ("/JobRequest", "job_request"),
+        ("/JobCancel", "job_cancel"),
+        ("/Job/Stream", "job_stream"),
+        ("/JobSegment/Stream", "job_segment_stream"),
+        ("/JobSegment/ByJob/JOB123", "job_segment_by_job"),
+        ("/Job/ByJobId/abc-123", "job_by_job_id"),
+        ("/Job/ByKey/JOB123", "job_by_key"),
+        ("/Dropoff", "dropoff"),
+        ("/SomethingNew/42", "other"),
+    ],
+)
+def test_api_endpoint_normalizes_paths(path, expected):
+    assert api_endpoint(path) == expected
+
+
+def _status_error(code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://x.example/JobRequest")
+    response = httpx.Response(code, request=request)
+    return httpx.HTTPStatusError("err", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    "exc,expected",
+    [
+        (httpx.ConnectTimeout("t"), "timeout"),
+        (httpx.ReadTimeout("t"), "timeout"),
+        (httpx.ConnectError("c"), "connect_error"),
+        (_status_error(404), "http_4xx"),
+        (_status_error(503), "http_5xx"),
+        (ValueError("x"), "other"),
+    ],
+)
+def test_error_kind_maps_exceptions(exc, expected):
+    assert error_kind(exc) == expected


### PR DESCRIPTION
Records the canonical inorbit_connector_upstream_http_* family for every FlowCore REST call and documents the optional metrics endpoint. All non-streaming OmronApiClient methods route through a single _request() choke point that times the call, records success or error (with a bounded error_kind), and re-raises so existing fallbacks are unchanged. SSE streaming endpoints record error events only. Endpoint labels are normalized through an explicit prefix table so dynamic IDs never reach Prometheus cardinality. The ARCL TCP client is not instrumented.

Includes the commented metrics: block in fleet.example.yaml and a README section. The endpoint itself is wired by the framework from config; metrics stay off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)