### PR TITLE
Bump omron_flowcore_connector version: 0.2.5 → 0.3.0

### DIFF
--- a/omron_flowcore_connector/pyproject.toml
+++ b/omron_flowcore_connector/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "inorbit-omron-connector"
-version = "0.2.5"
+version = "0.3.0"
 description = "InOrbit Connector for Omron FlowCore"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/omron_flowcore_connector/uv.lock
+++ b/omron_flowcore_connector/uv.lock
@@ -389,7 +389,7 @@ wheels = [
 
 [[package]]
 name = "inorbit-omron-connector"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosql" },


### PR DESCRIPTION
Version bump for the SDK 3.2 migration and observability stack. CI builds and pushes the 0.3.0 image on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)