### PR TITLE
Omron FlowCore connector: fix Docker publish trigger and release tag

### DIFF
--- a/.github/workflows/omron_flowcore_workflows.yml
+++ b/.github/workflows/omron_flowcore_workflows.yml
@@ -57,7 +57,7 @@ jobs:
 
 
   publish-docker:
-    if: ${{ contains(github.event.head_commit.message, 'Bump inorbit-omron-connector version') }}
+    if: ${{ contains(github.event.head_commit.message, 'Bump omron_flowcore_connector version') }}
     needs: [lint-and-test, reuse]
     runs-on: ubuntu-latest
     environment: release
@@ -104,11 +104,11 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ env.FLOWCORE_CONNECTOR_VERSION }}
-          name: Release v${{ env.FLOWCORE_CONNECTOR_VERSION }}
+          tag_name: omron_flowcore_connector-v${{ env.FLOWCORE_CONNECTOR_VERSION }}
+          name: Omron FLOW Core Connector v${{ env.FLOWCORE_CONNECTOR_VERSION }}
           body: |
-            Release v${{ env.FLOWCORE_CONNECTOR_VERSION }}
+            Omron FLOW Core Connector v${{ env.FLOWCORE_CONNECTOR_VERSION }}
 
-            Docker image: `us-central1-docker.pkg.dev/inorbit-integrations/inorbit-integrations/connectors/flowcore_connector:${{ env.FLOWCORE_CONNECTOR_VERSION }}`
+            Docker image: `us-central1-docker.pkg.dev/inorbit-integrations/connectors/flowcore_connector:${{ env.FLOWCORE_CONNECTOR_VERSION }}`
           draft: false
           prerelease: false

--- a/omron_flowcore_connector/CONTRIBUTING.md
+++ b/omron_flowcore_connector/CONTRIBUTING.md
@@ -113,7 +113,7 @@ To release a new version:
    ```
 
 1. > [!IMPORTANT]
-> The message of the last commit must match the configured pattern, e.g. "Bump inorbit-omron-connector version: 0.1.0 → 0.1.1", for the publish job to run.
+> The message of the commit that lands on `main` must match the configured pattern, e.g. "Bump omron_flowcore_connector version: 0.1.0 → 0.1.1", for the publish job to run. If the bump goes through a squash-merged PR, the squash commit message comes from the PR title, so the PR title must carry that pattern (the local commit message and tag are discarded by the squash).
 
 New releases are built and published to the Docker repository automatically by GitHub Actions when a new version bump commit is pushed.
 
@@ -123,9 +123,4 @@ To manually build and push the Docker image, run:
 ./docker/build.sh --push
 ```
 
-CI automatically publishes to PyPI when either:
-
-- A tag is pushed, or
-- A commit message contains "Bump version"
-
-After publishing to PyPI, CI also signs the artifacts and creates/updates the GitHub Release.
+After pushing the image, CI creates a GitHub Release tagged `omron_flowcore_connector-v<version>`. This connector is not published to PyPI.

--- a/omron_flowcore_connector/Makefile
+++ b/omron_flowcore_connector/Makefile
@@ -25,8 +25,8 @@ bump:
 	uv version --bump $$PART; \
 	new_version=$$(uv version --short); \
 	git add pyproject.toml uv.lock; \
-	git commit -m "Bump inorbit-omron-connector version: $${old_version} → $${new_version}"; \
-	git tag -a "inorbit-omron-connector-v$${new_version}" -m "Bump inorbit-omron-connector version: $${old_version} → $${new_version}"; \
+	git commit -m "Bump omron_flowcore_connector version: $${old_version} → $${new_version}"; \
+	git tag -a "omron_flowcore_connector-v$${new_version}" -m "Bump omron_flowcore_connector version: $${old_version} → $${new_version}"; \
 	echo "Bumped version $$old_version → $$new_version"
 
 bump-patch:


### PR DESCRIPTION
`publish-docker` matched `Bump inorbit-omron-connector version` (the package name), but version bumps reach `main` as squash-merged PRs, where the commit message is the PR title. 0.3.0 (#119) landed as `Bump omron_flowcore_connector version: 0.2.5 → 0.3.0`, so the job was skipped and no image was published ([run 30263906980](https://github.com/inorbit-ai/inorbit-robot-connectors/actions/runs/30263906980)).

Changes:
- Trigger, `make bump` commit message, and local tag all use `omron_flowcore_connector`, matching the other connectors and the PR titles already in use.
- GitHub Release tag is now `omron_flowcore_connector-v<version>` instead of the repo-global `v<version>`, which would collide with other connectors' releases.
- Release body image path lost a duplicated `inorbit-integrations` segment.
- CONTRIBUTING notes that the PR title carries the pattern under squash merges, and drops the stale PyPI section (there is no PyPI job for this connector).

0.3.0 is still unpublished. Once this merges, a 0.3.1 bump PR titled with the correct pattern will publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)