### PR TITLE
MiR connector: publish robot software version

### DIFF
--- a/mir_connector/inorbit_mir_connector/src/connector.py
+++ b/mir_connector/inorbit_mir_connector/src/connector.py
@@ -87,12 +87,13 @@ class MirConnector(Connector):
         )
 
         # Async robot wrapper managing polling
-        # Note: diagnostics endpoint does not exist on v2 firmware
-        enable_diagnostics = self._robot_config.mir_firmware_version != "v2"
+        # Note: diagnostics and software status endpoints do not exist on v2 firmware
+        is_v3 = self._robot_config.mir_firmware_version != "v2"
         self.robot = Robot(
             mir_api=self.mir_api,
             default_update_freq=1.0,  # 1 Hz status by default
-            enable_diagnostics=enable_diagnostics,
+            enable_diagnostics=is_v3,
+            enable_software_status=is_v3,
         )
 
         # Configure the timezone
@@ -436,6 +437,12 @@ class MirConnector(Connector):
             "waiting_for": self.mission_tracking.waiting_for_text,
             "api_connected": self.robot.api_connected,
         }
+
+        software = self.robot.software or {}
+        if (v := software.get("application_version")) is not None:
+            key_values["software_version"] = v
+        if (v := software.get("platform_version")) is not None:
+            key_values["platform_version"] = v
 
         # Add vitals from diagnostics (preferred) or status (fallback)
         # Keep localization_score from metrics only

--- a/mir_connector/inorbit_mir_connector/src/metrics.py
+++ b/mir_connector/inorbit_mir_connector/src/metrics.py
@@ -65,6 +65,7 @@ _api_endpoint_mapper = EndpointMapper(
         ("api/v2.0.0/mission_groups", "mission_groups"),
         ("api/v2.0.0/missions", "missions"),
         ("api/v2.0.0/maps", "maps"),
+        ("api/v2.0.0/software/system_status", "software_status"),
         # Bare-prefix variants (callers may pass relative paths)
         ("status", "status"),
         ("metrics", "metrics"),
@@ -73,6 +74,7 @@ _api_endpoint_mapper = EndpointMapper(
         ("mission_groups", "mission_groups"),
         ("missions", "missions"),
         ("maps", "maps"),
+        ("software/system_status", "software_status"),
     ]
 )
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_base.py
@@ -394,6 +394,24 @@ class MirApiBaseClass(ABC):
         pass
 
     @abstractmethod
+    async def get_software_status(self):
+        """Queries /software/system_status endpoint
+
+        Not available on v2 firmware. Returns an object, even though the API
+        docs declare an array e.g.
+            {
+                "platform_version": "3.9.1",
+                "application_version": "3.9.1",
+                "last_sw_update_type": "ROBOT_APPLICATION",
+                "last_sw_update_status": "Success",
+                "last_sw_update_date": "2026-07-29T04:18:26+00:00",
+                "free_disk_space": "34.6",
+                "used_disk_space": "4.19"
+            }
+        """
+        pass
+
+    @abstractmethod
     async def get_map(self, map_id: str):
         """Queries /maps/{map_id} endpoint.
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -32,6 +32,7 @@ MISSIONS_ENDPOINT_V2 = "missions"
 STATUS_ENDPOINT_V2 = "status"
 DIAGNOSTICS_ENDPOINT_V2 = "experimental/diagnostics"
 POSITIONS_ENDPOINT_V2 = "positions"
+SOFTWARE_STATUS_ENDPOINT_V2 = "software/system_status"
 
 
 class SetStateId(int, Enum):
@@ -377,6 +378,10 @@ class MirApiV2(MirApiBaseClass):
 
     async def get_diagnostics(self):
         response = await self._get(DIAGNOSTICS_ENDPOINT_V2)
+        return response.json()
+
+    async def get_software_status(self):
+        response = await self._get(f"/{SOFTWARE_STATUS_ENDPOINT_V2}")
         return response.json()
 
     async def get_map(self, map_id: str):

--- a/mir_connector/inorbit_mir_connector/src/robot/robot.py
+++ b/mir_connector/inorbit_mir_connector/src/robot/robot.py
@@ -10,6 +10,8 @@ from typing import Coroutine
 
 from inorbit_mir_connector.src.mir_api.mir_api_base import MirApiBaseClass
 
+SOFTWARE_STATUS_UPDATE_FREQ = 1 / 300
+
 
 class Robot:
     """
@@ -23,6 +25,7 @@ class Robot:
         mir_api: MirApiBaseClass,
         default_update_freq: float,
         enable_diagnostics: bool = True,
+        enable_software_status: bool = True,
     ):
         self.logger = logging.getLogger(name=self.__class__.__name__)
         self._mir_api = mir_api
@@ -30,10 +33,12 @@ class Robot:
         self._status: dict = {}
         self._metrics: dict = {}
         self._diagnostics: dict = {}
+        self._software: dict = {}
         self._default_update_freq = default_update_freq
         self._running_tasks: list[asyncio.Task] = []
         self._last_call_successful: bool = True
         self._enable_diagnostics = enable_diagnostics
+        self._enable_software_status = enable_software_status
 
         # Circuit breaker pattern for error handling
         self._consecutive_errors = 0
@@ -54,6 +59,8 @@ class Robot:
         # Note: diagnostics endpoint does not exist on v2 firmware
         if self._enable_diagnostics:
             self._run_in_loop(self._update_diagnostics, frequency=0.5)
+        if self._enable_software_status:
+            self._run_in_loop(self._update_software_status, frequency=SOFTWARE_STATUS_UPDATE_FREQ)
 
         self.logger.debug(f"Started {len(self._running_tasks)} polling tasks")
 
@@ -119,6 +126,16 @@ class Robot:
             self._handle_error(e, "robot diagnostics fetch")
             # Keep the last known diagnostics on error
 
+    async def _update_software_status(self) -> None:
+        """Fetch the robot software status from the API asynchronously."""
+        try:
+            software = await self._mir_api.get_software_status()
+            self._software = software
+            self._handle_success()
+        except Exception as e:
+            self._handle_error(e, "robot software status fetch")
+            # Keep the last known software status on error
+
     @property
     def status(self) -> dict:
         """Return the latest robot status"""
@@ -133,6 +150,11 @@ class Robot:
     def diagnostics(self) -> dict:
         """Return the latest robot diagnostics"""
         return self._diagnostics
+
+    @property
+    def software(self) -> dict:
+        """Return the latest robot software status"""
+        return self._software
 
     @property
     def api_connected(self) -> bool:

--- a/mir_connector/inorbit_mir_connector/tests/test_connector.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_connector.py
@@ -577,6 +577,55 @@ async def test_safety_decomposition_publishes_active_states(
 
 
 @pytest.mark.asyncio
+async def test_software_versions_published_when_available(
+    connector_with_mission_tracking, monkeypatch
+):
+    """Both versions are published from /software/system_status, and neither key
+    appears when the endpoint never answered (v2 firmware)."""
+    connector = connector_with_mission_tracking
+    connector.mission_tracking.report_mission = AsyncMock()
+
+    status_data = {
+        "robot_name": "Miriam",
+        "map_id": "m",
+        "position": {"x": 0.0, "y": 0.0, "orientation": 0.0},
+        "velocity": {"linear": 0.0, "angular": 0.0},
+    }
+    connector.robot._status = status_data
+    connector.mir_api.get_status.return_value = status_data
+    connector.publish_map = MagicMock()
+    connector.robot._metrics = {}
+    connector.mir_api.get_metrics.return_value = {}
+
+    mock_session = connector._get_session()
+    connector._get_session = MagicMock(return_value=mock_session)
+    connector._get_robot_session = MagicMock(return_value=mock_session)
+
+    # Versions differ: application and platform upgrade independently
+    connector.robot._software = {
+        "application_version": "3.9.1",
+        "platform_version": "3.8.1",
+        "used_disk_space": "4.19",
+    }
+    await connector._execution_loop()
+
+    key_values_call = mock_session.publish_key_values.call_args[0][0]
+    assert key_values_call["software_version"] == "3.9.1"
+    assert key_values_call["platform_version"] == "3.8.1"
+    # Unused fields from the same payload are not published
+    assert "used_disk_space" not in key_values_call
+
+    # v2 firmware never populates the cache → no null-valued keys
+    connector.robot._software = {}
+    mock_session.reset_mock()
+    await connector._execution_loop()
+
+    key_values_call = mock_session.publish_key_values.call_args[0][0]
+    assert "software_version" not in key_values_call
+    assert "platform_version" not in key_values_call
+
+
+@pytest.mark.asyncio
 async def test_connector_loop_publishes_system_stats(connector_with_mission_tracking, monkeypatch):
     """Test that system stats (CPU, RAM, disk) are published separately from key values."""
     connector = connector_with_mission_tracking

--- a/mir_connector/inorbit_mir_connector/tests/test_metrics.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_metrics.py
@@ -25,6 +25,8 @@ from inorbit_mir_connector.src.metrics import api_endpoint, error_kind
         ("/api/v2.0.0/mission_groups/abc-123/missions", "mission_groups"),
         ("/api/v2.0.0/missions/71e63050-7b7a-11ed", "missions"),
         ("/api/v2.0.0/maps/20f762ff-5e0a-11ee", "maps"),
+        ("/api/v2.0.0/software/system_status", "software_status"),
+        ("/software/system_status", "software_status"),
         # Callers may pass relative paths (httpx base_url joins them).
         ("status", "status"),
         ("mission_queue/14026", "mission_queue"),

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -71,6 +71,23 @@ async def test_get_executing_mission_id(mir_api, httpx_mock):
 
 
 @pytest.mark.asyncio
+async def test_get_software_status(mir_api, httpx_mock):
+    software = {
+        "platform_version": "3.9.1",
+        "application_version": "3.9.1",
+        "last_sw_update_type": "ROBOT_APPLICATION",
+        "last_sw_update_status": "Success",
+        "last_sw_update_date": "2026-07-29T04:18:26+00:00",
+        "free_disk_space": "34.6",
+        "used_disk_space": "4.19",
+    }
+    httpx_mock.add_response(
+        method="GET", url=f"{mir_api.mir_api_base_url}/software/system_status", json=software
+    )
+    assert await mir_api.get_software_status() == software
+
+
+@pytest.mark.asyncio
 async def test_abort_all_missions(mir_api, httpx_mock):
     httpx_mock.add_response(
         method="DELETE", url=f"{mir_api.mir_api_base_url}/mission_queue", status_code=204


### PR DESCRIPTION
## Description

Publishes the robot's MiR software version to InOrbit, so a robot's release is visible without opening the MiR web UI. `GET /software/system_status` returns clean JSON, unlike the other source of this data: `/metrics` carries the version as an `mir_robot_info` label, but the parser discards labels, the payload is OpenMetrics text, and the endpoint is already absent from MiR's newer V4 API doc variant.

`application_version` is published as `software_version`, matching MiR's own `mir_robot_info` label name and the existing key in the Gausium Open Platform connector. `platform_version` rides alongside it rather than being folded in, because the two upgrade independently (`last_sw_update_type: ROBOT_APPLICATION`) and can diverge even though they match on the 3.9.1 robot this was verified against.

The endpoint does not exist on v2 firmware (checked against the 2.7.0 REST API doc), so it reuses the existing `mir_firmware_version != "v2"` gate that already disables diagnostics there. No fallback path and no probing. Both keys are omitted when the cache is empty rather than published as null, so v2 robots and the window before the first successful fetch stay quiet.

Polling rather than fetching once, at 300s, so a robot upgraded mid-run republishes without a connector restart. `_run_in_loop` fetches before its first sleep, so the version lands on the first cycle. The shared circuit breaker is unaffected: 1Hz status polling resets the consecutive-error count, so a 404 every 300s can never reach the threshold.

`GET /system/info` was also checked on a real robot and carries only hardware serials and MAC addresses. Not used. `last_sw_update_*` and the disk-space fields are fetched but not published.

Tests cover the new API method, the endpoint label normalization, and the published keys in both the present and absent cases. `Robot.start()` and `_run_in_loop` have no coverage in this repo today and this adds none, so the 300s cadence itself is only verifiable against a live robot.

## Demo

<img width="404" height="42" alt="image" src="https://github.com/user-attachments/assets/98ea7b75-6b73-4bfb-ab78-db4249ae5555" />
