### PR TITLE
MiR connector: track native mission progress with InOrbit tasks

### DIFF
--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -809,9 +809,23 @@ missions, with one task per mission step. Steps appear in execution order and ar
 MiR labels them, for example `Move to Dock charger 285` or `Wait for 10 sec.`.
 
 Progress comes from the mission queue: each executed queue action names the definition action it
-came from, so a step is marked complete only when that action finished without failing. While the
-mission runs it reports status `OK`, or `warning` if the robot is paused, emergency-stopped or in
-an error state, which is what a stalled mission looks like from outside.
+came from, so a step is marked complete only when that action finished without failing.
+
+### Mission states
+
+MiR keeps a queue entry in `Executing` whether the robot is driving, paused or emergency-stopped,
+so the robot's own state supplies the rest. Each state maps to exactly one status:
+
+| Mission state    | Status    | When |
+| ---------------- | --------- | ---- |
+| `Executing`      | `OK`      | Running normally |
+| `Paused`         | `warning` | Robot paused; the mission is still open |
+| `Emergency stop` | `warning` | Emergency stop pressed mid-mission |
+| `Error`          | `error`   | Robot in an error state mid-mission |
+| `Done`           | `OK`      | Finished |
+| `Aborted`        | `error`   | Cancelled or failed |
+
+A blocked mission stays `inProgress`, so it is not closed out and resumes cleanly.
 
 ### Limitations
 

--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -21,7 +21,7 @@ The [InOrbit](https://inorbit.ai/) Robot Connector for [MiR Motors](https://dire
 - **Real-time Monitoring**: Robot pose, system status, battery levels, and error states
 - **Mission Control**: Dispatch, pause, cancel missions via [Actions](https://developer.inorbit.ai/docs#configuring-action-definitions), including [running MiR robot actions as mission steps](#-running-mir-actions-in-missions)
 - **Custom Scripts**: Execute custom shell scripts on the connector via Custom Actions
-- **Mission Tracking**: Full [Mission Tracking](https://developer.inorbit.ai/docs#configuring-mission-tracking) support
+- **Mission Tracking**: Full [Mission Tracking](https://developer.inorbit.ai/docs#configuring-mission-tracking) support, including robot-triggered (native) missions reported with per-action tasks labeled from the robot's action and position names
 - **SSL Support**: Secure connections with full certificate validation
 - **Multi-Robot Fleet Management**: Simplified configuration for managing multiple robots
 - **Docker Support**: Production-ready containerized deployment with Docker Compose

--- a/mir_connector/README.md
+++ b/mir_connector/README.md
@@ -21,7 +21,7 @@ The [InOrbit](https://inorbit.ai/) Robot Connector for [MiR Motors](https://dire
 - **Real-time Monitoring**: Robot pose, system status, battery levels, and error states
 - **Mission Control**: Dispatch, pause, cancel missions via [Actions](https://developer.inorbit.ai/docs#configuring-action-definitions), including [running MiR robot actions as mission steps](#-running-mir-actions-in-missions)
 - **Custom Scripts**: Execute custom shell scripts on the connector via Custom Actions
-- **Mission Tracking**: Full [Mission Tracking](https://developer.inorbit.ai/docs#configuring-mission-tracking) support, including robot-triggered (native) missions reported with per-action tasks labeled from the robot's action and position names
+- **Mission Tracking**: Full [Mission Tracking](https://developer.inorbit.ai/docs#configuring-mission-tracking) support, including [robot-triggered (native) missions](#-native-mission-tracking) reported step by step, in execution order, with the robot's own step labels
 - **SSL Support**: Secure connections with full certificate validation
 - **Multi-Robot Fleet Management**: Simplified configuration for managing multiple robots
 - **Docker Support**: Production-ready containerized deployment with Docker Compose
@@ -801,6 +801,32 @@ to that mission's GUID.
 - A rejected action (blank or denied `mir_actionType`) fails during translation, before any mission
   is created on the robot; nothing runs.
 - A failure identifies the mission, not which step within it failed.
+
+## 📊 Native Mission Tracking
+
+Missions started on the robot itself (from the MiR interface or a fleet) are reported to InOrbit as
+missions, with one task per mission step. Steps appear in execution order and are labeled the way
+MiR labels them, for example `Move to Dock charger 285` or `Wait for 10 sec.`.
+
+Progress comes from the mission queue: each executed queue action names the definition action it
+came from, so a step is marked complete only when that action finished without failing. While the
+mission runs it reports status `OK`, or `warning` if the robot is paused, emergency-stopped or in
+an error state, which is what a stalled mission looks like from outside.
+
+### Limitations
+
+- **Loops report one task per step, not per iteration.** A mission step inside a `loop` is a single
+  task, so it shows complete after the first pass and progress can reach 100% while later
+  iterations are still running.
+- **Untaken branches never complete.** Steps inside an `if` or `try_catch` branch that is not taken
+  stay unchecked, so a mission using them can finish below 100%.
+- **Sub-missions are not expanded.** A `load_mission` step runs the sub-mission's own actions, which
+  do not belong to the parent definition, so its internal steps are not tracked.
+- **Scope steps are not shown.** `loop`, `if`, `while`, `try_catch`, `prompt_user`,
+  `reduce_protective_fields`, `set_reset_io` and `set_reset_plc` are containers rather than steps
+  and are left out of the task list; the steps inside them are kept.
+- **Fleet ActionLists have no task list.** Missions dispatched by a MiR fleet carry no mission
+  definition, so they are reported with state and timing only.
 
 ## Next steps
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -26,6 +26,7 @@ API_V2_CONTEXT_URL = "/api/v2.0.0"
 
 # Endpoints
 METRICS_ENDPOINT_V2 = "metrics"
+ACTIONS_ENDPOINT_V2 = "actions"
 MISSION_QUEUE_ENDPOINT_V2 = "mission_queue"
 MISSION_GROUPS_ENDPOINT_V2 = "mission_groups"
 MISSIONS_ENDPOINT_V2 = "missions"
@@ -404,6 +405,17 @@ class MirApiV2(MirApiBaseClass):
         """
         offsets_api_url = f"/{POSITIONS_ENDPOINT_V2}/{position_guid}/docking_offsets"
         response = await self._get(offsets_api_url)
+        return response.json()
+
+    async def get_action_definitions(self):
+        """Action-type display metadata (``GET /actions``): one entry per
+        action_type with a localized ``name`` (Accept-Language is en_US)."""
+        response = await self._get(f"/{ACTIONS_ENDPOINT_V2}")
+        return response.json()
+
+    async def get_position(self, position_guid: str):
+        """Full position record (``GET /positions/{guid}``), including ``name``."""
+        response = await self._get(f"/{POSITIONS_ENDPOINT_V2}/{position_guid}")
         return response.json()
 
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -39,6 +39,10 @@ SOFTWARE_STATUS_ENDPOINT_V2 = "software/system_status"
 # default response; asking for it is what exposes the nesting between actions.
 MISSION_ACTION_FIELDS = "guid,action_type,priority,scope_reference,parameters"
 
+# Fields requested for action-type definitions. The default response has only action_type
+# and url; these are what task labels are rendered from.
+ACTION_DEFINITION_FIELDS = "action_type,name,description,parameters"
+
 
 class SetStateId(int, Enum):
     """Defined states for the set_state method"""
@@ -420,14 +424,16 @@ class MirApiV2(MirApiBaseClass):
         return response.json()
 
     async def get_action_definitions(self):
-        """Action-type display metadata (``GET /actions``): one entry per
-        action_type with a localized ``name`` (Accept-Language is en_US)."""
-        response = await self._get(f"/{ACTIONS_ENDPOINT_V2}")
-        return response.json()
+        """Metadata for every action type (``GET /actions``), one entry per action_type.
 
-    async def get_position(self, position_guid: str):
-        """Full position record (``GET /positions/{guid}``), including ``name``."""
-        response = await self._get(f"/{POSITIONS_ENDPOINT_V2}/{position_guid}")
+        The default response carries only ``action_type`` and ``url``; the whitelist is
+        what adds ``name``, the ``description`` label template ("Move to %(position)s")
+        and the per-parameter metadata used to fill that template in. All of it is
+        localized by the Accept-Language header (en_US).
+        """
+        response = await self._get(
+            f"/{ACTIONS_ENDPOINT_V2}", params={"whitelist": ACTION_DEFINITION_FIELDS}
+        )
         return response.json()
 
 

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -195,12 +195,10 @@ class MirApiV2(MirApiBaseClass):
         """Queries a list of actions a mission executes using
         the missions/{mission_id}/actions endpoint.
 
-        ``scope_reference`` is not in the default response and has to be whitelisted
-        (the default fields are action_type, guid, mission_id, parameters, priority, url).
-        It is what makes the list a tree: it holds the guid of a *parameter* of the action
-        that contains this one, or null at the top level. Without it, the response order
-        is meaningless and ``priority`` alone cannot be used, since it only orders siblings
-        inside a single scope. See ``mission_tracking._execution_order``.
+        ``scope_reference`` has to be whitelisted; it is not in the default response. It
+        holds the guid of a parameter of the action containing this one, or null at the
+        top level, and is what makes the list a tree. See
+        ``mission_tracking._execution_order``.
         """
         actions_api_url = f"/{MISSIONS_ENDPOINT_V2}/{mission_id}/actions"
         response = await self._get(actions_api_url, params={"whitelist": MISSION_ACTION_FIELDS})
@@ -245,9 +243,10 @@ class MirApiV2(MirApiBaseClass):
         ``GET /mission_queue/{id}/actions/{action_int_id}`` returns the rich
         entry: ``{id, action_id, state, started, finished, action_type,
         parameters}``. ``action_id`` equals the mission-definition action guid
-        (what ``add_action_to_mission`` returns), so it maps a running queue
-        action back to the action we created. Completion signal is ``finished``
-        (a timestamp once done); ``state`` can be ``""`` even when finished.
+        (what ``add_action_to_mission`` returns), which is what maps a running
+        queue action back to its definition. ``finished`` is a timestamp once the
+        action is over; an empty ``state`` is what distinguishes success from
+        ``"Failed"`` or ``"Aborted"``.
         """
         action_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}/{queue_id}/actions/{action_int_id}"
         response = await self._get(action_api_url)
@@ -256,15 +255,13 @@ class MirApiV2(MirApiBaseClass):
     async def get_executing_mission_id(self):
         """Returns the id of the mission being currently executed by the robot.
 
-        Reads the newest slice of the queue rather than all of it. The queue is never
-        truncated by the robot, so on a robot that has been running for a while the
-        unbounded call is enormous: 28,526 entries, 2 MB, ~3.9 s on our MiR100, which a
-        1 s poll cannot keep up with. An executing entry is by construction among the
-        newest, and the whitelist trims each one to the two fields used here.
+        Reads the newest slice of the queue rather than all of it: the robot never
+        truncates the queue, so unbounded this grows to megabytes and takes longer than
+        the poll interval. An executing entry is always among the newest.
 
-        Note that MiR ignores query params it does not recognise instead of rejecting
-        them, so limit and sort_by have to be kept together: limit alone would silently
-        read the oldest entries.
+        ``limit`` and ``sort_by`` must be sent together. MiR ignores query params it does
+        not recognise rather than rejecting them, so ``limit`` alone would read the
+        oldest entries.
         """
         missions_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}"
         response = await self._get(

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -43,6 +43,10 @@ MISSION_ACTION_FIELDS = "guid,action_type,priority,scope_reference,parameters"
 # and url; these are what task labels are rendered from.
 ACTION_DEFINITION_FIELDS = "action_type,name,description,parameters"
 
+# How much of the tail of the mission queue to read when looking for the executing entry.
+# Slack for entries queued behind it; the queue itself is never truncated by the robot.
+RECENT_QUEUE_ENTRIES = 20
+
 
 class SetStateId(int, Enum):
     """Defined states for the set_state method"""
@@ -250,9 +254,23 @@ class MirApiV2(MirApiBaseClass):
         return response.json()
 
     async def get_executing_mission_id(self):
-        """Returns the id of the mission being currently executed by the robot"""
+        """Returns the id of the mission being currently executed by the robot.
+
+        Reads the newest slice of the queue rather than all of it. The queue is never
+        truncated by the robot, so on a robot that has been running for a while the
+        unbounded call is enormous: 28,526 entries, 2 MB, ~3.9 s on our MiR100, which a
+        1 s poll cannot keep up with. An executing entry is by construction among the
+        newest, and the whitelist trims each one to the two fields used here.
+
+        Note that MiR ignores query params it does not recognise instead of rejecting
+        them, so limit and sort_by have to be kept together: limit alone would silently
+        read the oldest entries.
+        """
         missions_api_url = f"/{MISSION_QUEUE_ENDPOINT_V2}"
-        response = await self._get(missions_api_url)
+        response = await self._get(
+            missions_api_url,
+            params={"limit": RECENT_QUEUE_ENTRIES, "sort_by": "id,desc", "whitelist": "id,state"},
+        )
         missions = response.json()
         executing = [m for m in missions if m["state"] == MISSION_STATE_EXECUTING]
         return executing[0]["id"] if len(executing) else None

--- a/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/src/mir_api/mir_api_v2.py
@@ -35,6 +35,10 @@ DIAGNOSTICS_ENDPOINT_V2 = "experimental/diagnostics"
 POSITIONS_ENDPOINT_V2 = "positions"
 SOFTWARE_STATUS_ENDPOINT_V2 = "software/system_status"
 
+# Fields requested for mission definition actions. Everything but scope_reference is in the
+# default response; asking for it is what exposes the nesting between actions.
+MISSION_ACTION_FIELDS = "guid,action_type,priority,scope_reference,parameters"
+
 
 class SetStateId(int, Enum):
     """Defined states for the set_state method"""
@@ -181,9 +185,17 @@ class MirApiV2(MirApiBaseClass):
 
     async def get_mission_actions(self, mission_id):
         """Queries a list of actions a mission executes using
-        the missions/{mission_id}/actions endpoint"""
+        the missions/{mission_id}/actions endpoint.
+
+        ``scope_reference`` is not in the default response and has to be whitelisted
+        (the default fields are action_type, guid, mission_id, parameters, priority, url).
+        It is what makes the list a tree: it holds the guid of a *parameter* of the action
+        that contains this one, or null at the top level. Without it, the response order
+        is meaningless and ``priority`` alone cannot be used, since it only orders siblings
+        inside a single scope. See ``mission_tracking._execution_order``.
+        """
         actions_api_url = f"/{MISSIONS_ENDPOINT_V2}/{mission_id}/actions"
-        response = await self._get(actions_api_url)
+        response = await self._get(actions_api_url, params={"whitelist": MISSION_ACTION_FIELDS})
         actions = response.json()
         return actions
 

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -34,9 +34,8 @@
 #     `finished` timestamp. Matching by guid (not list length) ignores a load_mission's
 #     inlined sub-actions, whose guids are foreign to our set, so nested missions no longer
 #     over-complete. Best-effort: a tracking error never aborts the completion poll.
-#   - 2026-08-13: a queue action's `finished` timestamp is set on failures too, so completion
-#     now also requires an empty `state` ("Failed"/"Aborted" mean it did not succeed);
-#     previously a failed action marked its paired InOrbit task completed
+#   - 2026-08-13: completion now also requires an empty `state`, since a queue action's
+#     `finished` timestamp is set on failures too ("Failed"/"Aborted" did not succeed)
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 

--- a/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
+++ b/mir_connector/inorbit_mir_connector/src/mission/behavior_tree.py
@@ -34,6 +34,9 @@
 #     `finished` timestamp. Matching by guid (not list length) ignores a load_mission's
 #     inlined sub-actions, whose guids are foreign to our set, so nested missions no longer
 #     over-complete. Best-effort: a tracking error never aborts the completion poll.
+#   - 2026-08-13: a queue action's `finished` timestamp is set on failures too, so completion
+#     now also requires an empty `state` ("Failed"/"Aborted" mean it did not succeed);
+#     previously a failed action marked its paired InOrbit task completed
 
 """Custom behavior tree nodes for executing compiled native MiR missions.
 
@@ -338,7 +341,8 @@ class WaitForMirMissionCompletionNode(BehaviorTree):
                 detail = await self._mir_api.get_mission_queue_action(queue_id, int_id)
                 self._detail_cache[int_id] = (
                     detail.get("action_id"),
-                    detail.get("finished") is not None,
+                    # `finished` is set on failures too; an empty `state` is what marks success.
+                    detail.get("finished") is not None and not detail.get("state"),
                 )
         except Exception as e:
             logger.warning(f"Failed to poll per-action progress for {queue_id}: {e}")

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -233,16 +233,11 @@ class MirInorbitMissionTracking:
             return
         tracker = self._tasks_tracker
         task_fields = {}
+        completed_percent = None
         if tracker is not None:
             await tracker.poll()
             task_fields = tracker.report_fields()
             completed_percent = task_fields.pop("completedPercent")
-        else:
-            # No tracker (test-mocked paths): count-based estimate as before.
-            completed_percent = min(
-                1.0,
-                len(mission.get("actions", [])) / max(1, len(mission["definition"]["actions"])),
-            )
         # Merge 'Abort' and 'Aborted' values into a single state
         if mission["state"] == MISSION_STATE_ABORT:
             mission["state"] = MISSION_STATE_ABORTED
@@ -277,7 +272,7 @@ class MirInorbitMissionTracking:
             mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
             mission_values["completedPercent"] = 1
             mission_values["status"] = "OK" if mission["state"] == MISSION_STATE_DONE else "error"
-        else:
+        elif completed_percent is not None:
             mission_values["completedPercent"] = completed_percent
 
         self.logger.debug(f"Reporting mission: {mission_values}")

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -11,6 +11,80 @@ MISSION_STATE_DONE = "Done"
 MISSION_STATE_ABORT = "Abort"
 
 
+class MirNativeMissionTasks:
+    """Per-action InOrbit task progress for one native (robot-triggered) mission.
+
+    Tasks are the mission definition's actions. Progress comes from the mission
+    queue actions endpoints: each executed queue action's ``action_id`` equals a
+    definition action guid. Completed tasks never downgrade; poll failures keep
+    the previous states.
+    """
+
+    def __init__(self, mir_api, queue_id, tasks):
+        self.logger = logging.getLogger(name=self.__class__.__name__)
+        self._mir_api = mir_api
+        self._queue_id = queue_id
+        # Ordered {definition action guid: task dict}, mutated in place as progress arrives.
+        self._tasks = tasks
+        self._current_task_id = None
+        # queue-action int id -> (action_id guid, finished bool). Finished entries are
+        # never re-fetched, so steady state costs one shallow GET per poll.
+        self._detail_cache = {}
+
+    async def poll(self):
+        """Refresh task states from the mission queue actions. Never raises."""
+        try:
+            entries = await self._mir_api.get_mission_queue_actions(self._queue_id)
+            for entry in entries:
+                int_id = entry.get("id")
+                cached = self._detail_cache.get(int_id)
+                if cached is not None and cached[1]:
+                    continue
+                detail = await self._mir_api.get_mission_queue_action(self._queue_id, int_id)
+                self._detail_cache[int_id] = (
+                    detail.get("action_id"),
+                    detail.get("finished") is not None,
+                )
+        except Exception as e:
+            self.logger.warning(f"Failed to poll actions of mission queue {self._queue_id}: {e}")
+            return
+        self._apply()
+
+    def _apply(self):
+        """Fold the detail cache (in execution order) into task states."""
+        current = None
+        for guid, finished in self._detail_cache.values():
+            task = self._tasks.get(guid)
+            if task is None:  # foreign guid, e.g. a load_mission inlined sub-action
+                continue
+            if finished:
+                task["completed"] = True
+                task["inProgress"] = False
+            elif not task["completed"]:
+                task["inProgress"] = True
+                current = guid
+        self._current_task_id = current
+
+    def report_fields(self):
+        """``tasks``/``completedPercent``/``currentTaskId`` fields for the report payload."""
+        tasks = list(self._tasks.values())
+        completed = sum(1 for t in tasks if t["completed"])
+        fields = {
+            "tasks": [dict(t) for t in tasks],
+            "completedPercent": completed / len(tasks) if tasks else 0,
+        }
+        if self._current_task_id:
+            fields["currentTaskId"] = self._current_task_id
+        return fields
+
+    def signature(self):
+        """Hashable snapshot of task states, for report deduplication."""
+        return (
+            self._current_task_id,
+            tuple((t["inProgress"], t["completed"]) for t in self._tasks.values()),
+        )
+
+
 class MirInorbitMissionTracking:
 
     def __init__(

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -21,16 +21,16 @@ MISSION_STATUS_OK = "OK"
 MISSION_STATUS_WARNING = "warning"
 MISSION_STATUS_ERROR = "error"
 
-# States we report on top of MiR's own. MiR leaves the queue entry "Executing" whether the
-# robot is driving, paused or e-stopped, so a stalled mission is invisible in the queue
-# state alone and the robot state has to supply it.
+# Mission states derived from the robot rather than the queue. MiR leaves a queue entry
+# "Executing" whether the robot is driving, paused or e-stopped, so a stalled mission is
+# invisible in the queue state alone.
 MISSION_STATE_PAUSED = "Paused"
 MISSION_STATE_EMERGENCY_STOP = "Emergency stop"
 MISSION_STATE_ERROR = "Error"
 
 # Robot state_id -> the mission state it implies while the queue entry is still executing.
-# Only 4 is corroborated (it is MirApiV2.SetStateId.PAUSE); the other two are unobserved so
-# far, and an unknown id simply leaves the mission executing.
+# Only 4 is confirmed (MirApiV2.SetStateId.PAUSE); an unrecognised id leaves the mission
+# executing.
 _STATE_BY_ROBOT_STATE_ID = {
     4: MISSION_STATE_PAUSED,
     10: MISSION_STATE_EMERGENCY_STOP,
@@ -166,8 +166,8 @@ def _execution_order(actions):
                     walk(nested)
 
     walk(None)
-    # Anything unreachable from the root (a scope_reference we never saw as a parameter)
-    # is appended rather than dropped, so a task is never silently lost.
+    # Actions unreachable from the root are appended rather than dropped, so a malformed
+    # scope_reference cannot silently lose a task.
     placed = {id(a) for a in ordered}
     return ordered + [a for a in actions if id(a) not in placed]
 
@@ -349,16 +349,15 @@ class MirInorbitMissionTracking:
     async def _find_executing_mission_id(self, robot_status):
         """Queue id of the mission the robot is running, or None.
 
-        ``/status`` carries it and the connector already fetches ``/status`` every tick,
-        so this normally costs nothing at all. The queue endpoint is only consulted when
-        the field is missing.
+        ``/status`` carries it and is already fetched every tick, so this normally costs
+        nothing. The queue endpoint is only consulted when the field is missing.
         """
         if robot_status and "mission_queue_id" in robot_status:
             queue_id = robot_status["mission_queue_id"]
         else:
             queue_id = await self.mir_api.get_executing_mission_id()
-        # The field clears when the mission ends, but if a firmware ever left it set we
-        # would re-adopt an entry we have already finished with and republish it forever.
+        # An already-finished entry is refused: the field clears when a mission ends, but
+        # a firmware that left it set would make the entry republish on every tick.
         return None if queue_id == self._finished_mission_id else queue_id
 
     async def get_current_mission(self, robot_status=None):
@@ -453,8 +452,8 @@ class MirInorbitMissionTracking:
             mission_values["data"]["Mission Steps"] = len(definition["actions"])
         if mission.get("finished") is not None:
             mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
-            # Only a mission that ran to the end is 100%. An abort at step 2 of 10 used to
-            # report 1.0, contradicting the task list in the same payload.
+            # Only a mission that ran to the end is 100%; an aborted one keeps the
+            # progress it reached, matching the task list sent alongside it.
             if mission["state"] == MISSION_STATE_DONE:
                 completed_percent = 1
         if completed_percent is not None:

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -253,9 +253,7 @@ class MirInorbitMissionTracking:
             "label": mission["definition"]["name"],
             "startTs": self._safe_localize_timestamp(mission["started"]) * 1000,
             "data": {
-                "Total Distance (m)": metrics.get(
-                    "mir_robot_distance_moved_meters_total", "N/A"
-                ),
+                "Total Distance (m)": metrics.get("mir_robot_distance_moved_meters_total", "N/A"),
                 "Mission Steps": len(mission["definition"]["actions"]),
                 "Total Missions": mission["id"],
                 "Robot Model": status["robot_model"],
@@ -269,9 +267,7 @@ class MirInorbitMissionTracking:
         if mission.get("finished") is not None:
             mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
             mission_values["completedPercent"] = 1
-            mission_values["status"] = (
-                "OK" if mission["state"] == MISSION_STATE_DONE else "error"
-            )
+            mission_values["status"] = "OK" if mission["state"] == MISSION_STATE_DONE else "error"
         else:
             mission_values["completedPercent"] = completed_percent
 

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -10,6 +10,10 @@ from inorbit_edge.missions import MISSION_STATE_EXECUTING, MISSION_STATE_ABORTED
 MISSION_STATE_DONE = "Done"
 MISSION_STATE_ABORT = "Abort"
 
+# Definition action parameter ids whose value is a position guid, with the label phrase
+# used to join the resolved position name ("Move to X", "Docking at X").
+POSITION_PARAM_PHRASES = {"position": "to", "marker": "at"}
+
 
 class MirNativeMissionTasks:
     """Per-action InOrbit task progress for one native (robot-triggered) mission.
@@ -103,6 +107,61 @@ class MirInorbitMissionTracking:
         self.inorbit_sess = inorbit_sess
         self.robot_tz_info = robot_tz_info
         self.mission_executor = mission_executor
+        self._action_names = None  # {action_type: display name}, fetched once, kept for life
+        self._position_names = {}  # {position guid: name}, kept for life
+
+    async def _get_action_names(self):
+        """Action-type display names, fetched once and cached; {} (and a retry on the
+        next mission) when the fetch fails."""
+        if self._action_names is None:
+            try:
+                defs = await self.mir_api.get_action_definitions()
+                self._action_names = {
+                    d["action_type"]: d.get("name") for d in defs if d.get("action_type")
+                }
+            except Exception as e:
+                self.logger.warning(f"Failed to fetch MiR action definitions: {e}")
+                return {}
+        return self._action_names
+
+    async def _build_label(self, action, action_names):
+        """Operator-facing task label: action display name, plus the resolved position
+        name when the action targets one ("Move to Warehouse-1"). Best-effort."""
+        label = action_names.get(action["action_type"]) or action["action_type"]
+        for param in action.get("parameters") or []:
+            phrase = POSITION_PARAM_PHRASES.get(param.get("id"))
+            value = param.get("value")
+            if not phrase or not isinstance(value, str) or not value:
+                continue
+            name = self._position_names.get(value)
+            if name is None:
+                try:
+                    name = (await self.mir_api.get_position(value)).get("name")
+                    if name:
+                        self._position_names[value] = name
+                except Exception as e:
+                    self.logger.debug(f"Could not resolve position {value} for label: {e}")
+            if name:
+                label = f"{label} {phrase} {name}"
+            break
+        return label
+
+    async def _build_tasks(self, actions):
+        """Ordered {guid: task dict} from the mission definition actions (flat list,
+        including actions nested in scopes)."""
+        action_names = await self._get_action_names()
+        tasks = {}
+        for action in actions:
+            guid = action.get("guid")
+            if not guid:
+                continue
+            tasks[guid] = {
+                "taskId": guid,
+                "label": await self._build_label(action, action_names),
+                "inProgress": False,
+                "completed": False,
+            }
+        return tasks
 
     def _safe_localize_timestamp(self, timestamp_str: str) -> float:
         """Convert ISO timestamp string to Unix timestamp, handling timezone conversion.

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -18,6 +18,18 @@ POSITION_PARAM_PHRASES = {"position": "to", "marker": "at"}
 _MAX_DETAIL_FETCHES_PER_POLL = 25
 
 
+def _action_outcome(detail):
+    """``(finished, succeeded)`` for a queue action detail.
+
+    ``finished`` is a timestamp on failures too, so it alone does not mean success: a
+    successful action reports an empty ``state``, a failed one "Failed" or "Aborted".
+    The two flags are kept apart because a failed action is neither still running nor
+    completed, and InOrbit tasks express that as both booleans false.
+    """
+    finished = detail.get("finished") is not None
+    return finished, finished and not detail.get("state")
+
+
 class MirNativeMissionTasks:
     """Per-action InOrbit task progress for one native (robot-triggered) mission.
 
@@ -34,8 +46,8 @@ class MirNativeMissionTasks:
         # Ordered {definition action guid: task dict}, mutated in place as progress arrives.
         self._tasks = tasks
         self._current_task_id = None
-        # queue-action int id -> (action_id guid, finished bool). Finished entries are
-        # never re-fetched, so steady state costs one shallow GET per poll.
+        # queue-action int id -> (action_id guid, finished bool, succeeded bool). Finished
+        # entries are never re-fetched, so steady state costs one shallow GET per poll.
         self._detail_cache = {}
 
     async def poll(self):
@@ -53,10 +65,7 @@ class MirNativeMissionTasks:
                     # ticks converge.
                     break
                 detail = await self._mir_api.get_mission_queue_action(self._queue_id, int_id)
-                self._detail_cache[int_id] = (
-                    detail.get("action_id"),
-                    detail.get("finished") is not None,
-                )
+                self._detail_cache[int_id] = (detail.get("action_id"), *_action_outcome(detail))
                 fetched += 1
         except Exception as e:
             self.logger.warning(f"Failed to poll actions of mission queue {self._queue_id}: {e}")
@@ -66,12 +75,15 @@ class MirNativeMissionTasks:
     def _apply(self):
         """Fold the detail cache (in execution order) into task states."""
         current = None
-        for guid, finished in self._detail_cache.values():
+        for guid, finished, succeeded in self._detail_cache.values():
             task = self._tasks.get(guid)
             if task is None:  # foreign guid, e.g. a load_mission inlined sub-action
                 continue
-            if finished:
+            if succeeded:
                 task["completed"] = True
+                task["inProgress"] = False
+            elif finished:
+                # Ran and failed: not completed, and no longer running either.
                 task["inProgress"] = False
             elif not task["completed"]:
                 task["inProgress"] = True

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import re
 from datetime import datetime
 from inorbit_edge.missions import MISSION_STATE_EXECUTING, MISSION_STATE_ABORTED
 
@@ -12,12 +13,80 @@ from .mission.translator import _SCOPE_BEARING_DENIED
 MISSION_STATE_DONE = "Done"
 MISSION_STATE_ABORT = "Abort"
 
-# Definition action parameter ids whose value is a position guid, with the label phrase
-# used to join the resolved position name ("Move to X", "Docking at X").
-POSITION_PARAM_PHRASES = {"position": "to", "marker": "at"}
-
 # Max detail GETs issued in a single poll tick.
 _MAX_DETAIL_FETCHES_PER_POLL = 25
+
+# A substitution in a MiR action description, e.g. "%(position)s" or "%(register)d".
+_PLACEHOLDER = re.compile(r"%\((\w+)\)[a-z]")
+# MiR durations are "HH:MM:SS.ffffff".
+_DURATION = re.compile(r"^(\d+):(\d{2}):(\d{2})(?:\.\d+)?$")
+
+
+def _pretty_duration(value):
+    """Render a MiR duration as "1 min 30 sec"; None when the value is not one."""
+    match = _DURATION.match(str(value))
+    if not match:
+        return None
+    hours, minutes, seconds = (int(g) for g in match.groups())
+    parts = [f"{n} {unit}" for n, unit in ((hours, "h"), (minutes, "min"), (seconds, "sec")) if n]
+    return " ".join(parts) or "0 sec"
+
+
+def _resolve_parameter(value, spec):
+    """Display text for one action parameter value, or None when it cannot be resolved.
+
+    ``Reference`` and ``Selection`` parameters carry the whole value-to-name mapping in
+    their own constraints, which is how a position guid becomes "Dock charger 285"
+    without asking the robot anything.
+    """
+    param_type = spec.get("type")
+    if param_type in ("Reference", "Selection"):
+        choices = (spec.get("constraints") or {}).get("choices") or []
+        # MiR is loose about types here: a choice value may be int 1 where the action
+        # stores the string "1".
+        match = next((c for c in choices if str(c.get("value")) == str(value)), None)
+        if match is None:
+            # Typically a deleted position still referenced by the mission.
+            return None
+        # Some references (PLC registers) have blank names; the raw value is the label.
+        return match.get("name") or str(value)
+    if param_type == "Duration":
+        return _pretty_duration(value)
+    return None if value is None else str(value)
+
+
+def _render_label(action, definition):
+    """Operator-facing label for a definition action, built from MiR's own metadata.
+
+    Every action type ships a ``description`` template ("Move to %(position)s") and, per
+    parameter, the type and value list needed to fill it in. Falls back to the action's
+    display name, then to its raw type, so an unresolvable placeholder yields "Move"
+    rather than a guid. Nothing here is per-action-type.
+    """
+    # Not every action type is listed in GET /actions (load_mission is not), so the raw
+    # type is the last resort: "load_mission" -> "Load mission".
+    name = definition.get("name") or action["action_type"].replace("_", " ").capitalize()
+    template = definition.get("description")
+    if not template:
+        return name
+    specs = {p["id"]: p for p in definition.get("parameters") or []}
+    resolved = {
+        p["id"]: _resolve_parameter(p.get("value"), specs.get(p["id"], {}))
+        for p in action.get("parameters") or []
+        if p.get("id")
+    }
+    complete = True
+
+    def substitute(match):
+        nonlocal complete
+        text = resolved.get(match.group(1))
+        if not text:
+            complete = False
+            return ""
+        return text
+
+    label = _PLACEHOLDER.sub(substitute, template).strip()
+    return label if complete and label else name
 
 
 def _execution_order(actions):
@@ -170,47 +239,26 @@ class MirInorbitMissionTracking:
         self.inorbit_sess = inorbit_sess
         self.robot_tz_info = robot_tz_info
         self.mission_executor = mission_executor
-        self._action_names = None  # {action_type: display name}, fetched once, kept for life
-        self._position_names = {}  # {position guid: name}, kept for life
+        # {action_type: definition}, one fetch for the life of the connector. Carries the
+        # label templates and the parameter value lists task labels are rendered from.
+        self._action_definitions = None
         self._mission_definition = None  # definition of the tracked mission, one fetch per entry
         self._tasks_tracker = None  # MirNativeMissionTasks for the tracked queue entry
         self.last_reported_tasks_signature = None
 
-    async def _get_action_names(self):
-        """Action-type display names, fetched once and cached; {} (and a retry on the
-        next mission) when the fetch fails."""
-        if self._action_names is None:
+    async def _get_action_definitions(self):
+        """{action_type: definition}, fetched once and cached; {} (and a retry on the next
+        mission) when the fetch fails."""
+        if self._action_definitions is None:
             try:
                 defs = await self.mir_api.get_action_definitions()
-                self._action_names = {
-                    d["action_type"]: d.get("name") for d in defs if d.get("action_type")
+                self._action_definitions = {
+                    d["action_type"]: d for d in defs if d.get("action_type")
                 }
             except Exception as e:
                 self.logger.warning(f"Failed to fetch MiR action definitions: {e}")
                 return {}
-        return self._action_names
-
-    async def _build_label(self, action, action_names):
-        """Operator-facing task label: action display name, plus the resolved position
-        name when the action targets one ("Move to Warehouse-1"). Best-effort."""
-        label = action_names.get(action["action_type"]) or action["action_type"]
-        for param in action.get("parameters") or []:
-            phrase = POSITION_PARAM_PHRASES.get(param.get("id"))
-            value = param.get("value")
-            if not phrase or not isinstance(value, str) or not value:
-                continue
-            name = self._position_names.get(value)
-            if name is None:
-                try:
-                    name = (await self.mir_api.get_position(value)).get("name")
-                    if name:
-                        self._position_names[value] = name
-                except Exception as e:
-                    self.logger.debug(f"Could not resolve position {value} for label: {e}")
-            if name:
-                label = f"{label} {phrase} {name}"
-            break
-        return label
+        return self._action_definitions
 
     async def _build_tasks(self, actions):
         """{guid: task dict} in execution order, one task per real mission step.
@@ -220,7 +268,7 @@ class MirInorbitMissionTracking:
         while their body runs they would show as a second task in progress. Their
         children stay, in place.
         """
-        action_names = await self._get_action_names()
+        definitions = await self._get_action_definitions()
         tasks = {}
         for action in _execution_order(actions):
             guid = action.get("guid")
@@ -228,7 +276,7 @@ class MirInorbitMissionTracking:
                 continue
             tasks[guid] = {
                 "taskId": guid,
-                "label": await self._build_label(action, action_names),
+                "label": _render_label(action, definitions.get(action["action_type"], {})),
                 "inProgress": False,
                 "completed": False,
             }

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -109,6 +109,8 @@ class MirInorbitMissionTracking:
         self.mission_executor = mission_executor
         self._action_names = None  # {action_type: display name}, fetched once, kept for life
         self._position_names = {}  # {position guid: name}, kept for life
+        self._mission_definition = None  # definition of the tracked mission, one fetch per entry
+        self._tasks_tracker = None  # MirNativeMissionTasks for the tracked queue entry
 
     async def _get_action_names(self):
         """Action-type display names, fetched once and cached; {} (and a retry on the
@@ -183,17 +185,32 @@ class MirInorbitMissionTracking:
             return datetime.now().timestamp()
 
     async def get_current_mission(self):
-        """Return the current mission, it's either executing or just ended"""
-        mission = None
+        """Return the current mission, it's either executing or just ended.
+
+        The queue entry is fetched every tick; the definition (with actions) once per
+        queue entry, when the per-action task tracker is also (re)built.
+        """
         if self.executing_mission_id is None:
             self.executing_mission_id = await self.mir_api.get_executing_mission_id()
-        if self.executing_mission_id:
-            mission = await self.mir_api.get_mission(self.executing_mission_id)
-            if mission["state"] != MISSION_STATE_EXECUTING:
-                # Update executing_mission_id so the next call to this method returns the next
-                # executing mission or None.
-                # Note that the current call in this case returns the just finished mission
-                self.executing_mission_id = None
+            self._mission_definition = None
+            self._tasks_tracker = None
+        if not self.executing_mission_id:
+            return None
+        queue_id = self.executing_mission_id
+        mission = await self.mir_api.get_mission_queue_entry(queue_id)
+        if self._mission_definition is None:
+            definition = await self.mir_api.get_mission_definition(mission["mission_id"])
+            definition["actions"] = await self.mir_api.get_mission_actions(mission["mission_id"])
+            self._mission_definition = definition
+            self._tasks_tracker = MirNativeMissionTasks(
+                self.mir_api, queue_id, await self._build_tasks(definition["actions"])
+            )
+        mission["definition"] = self._mission_definition
+        if mission["state"] != MISSION_STATE_EXECUTING:
+            # Update executing_mission_id so the next call to this method returns the next
+            # executing mission or None.
+            # Note that the current call in this case returns the just finished mission
+            self.executing_mission_id = None
         return mission
 
     async def report_mission(self, status, metrics):

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -14,6 +14,9 @@ MISSION_STATE_ABORT = "Abort"
 # used to join the resolved position name ("Move to X", "Docking at X").
 POSITION_PARAM_PHRASES = {"position": "to", "marker": "at"}
 
+# Max detail GETs issued in a single poll tick.
+_MAX_DETAIL_FETCHES_PER_POLL = 25
+
 
 class MirNativeMissionTasks:
     """Per-action InOrbit task progress for one native (robot-triggered) mission.
@@ -39,16 +42,22 @@ class MirNativeMissionTasks:
         """Refresh task states from the mission queue actions. Never raises."""
         try:
             entries = await self._mir_api.get_mission_queue_actions(self._queue_id)
+            fetched = 0
             for entry in entries:
                 int_id = entry.get("id")
                 cached = self._detail_cache.get(int_id)
                 if cached is not None and cached[1]:
                     continue
+                if fetched >= _MAX_DETAIL_FETCHES_PER_POLL:
+                    # ponytail: caps the catch-up burst when attaching mid-mission; later
+                    # ticks converge.
+                    break
                 detail = await self._mir_api.get_mission_queue_action(self._queue_id, int_id)
                 self._detail_cache[int_id] = (
                     detail.get("action_id"),
                     detail.get("finished") is not None,
                 )
+                fetched += 1
         except Exception as e:
             self.logger.warning(f"Failed to poll actions of mission queue {self._queue_id}: {e}")
             return
@@ -229,7 +238,7 @@ class MirInorbitMissionTracking:
             task_fields = tracker.report_fields()
             completed_percent = task_fields.pop("completedPercent")
         else:
-            # No tracker (mocked or degraded paths): count-based estimate as before.
+            # No tracker (test-mocked paths): count-based estimate as before.
             completed_percent = min(
                 1.0,
                 len(mission.get("actions", [])) / max(1, len(mission["definition"]["actions"])),

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -16,6 +16,32 @@ MISSION_STATE_ABORT = "Abort"
 # Max detail GETs issued in a single poll tick.
 _MAX_DETAIL_FETCHES_PER_POLL = 25
 
+# InOrbit mission statuses. Matched exactly by the platform, so the case matters.
+MISSION_STATUS_OK = "OK"
+MISSION_STATUS_WARNING = "warning"
+MISSION_STATUS_ERROR = "error"
+
+# Robot state ids that stop a running mission making progress.
+_BLOCKED_STATE_IDS = frozenset({4, 10, 12})  # Pause, EmergencyStop, Error
+
+
+def _mission_status(mission, robot_status):
+    """InOrbit status for a MiR queue entry: OK, warning or error.
+
+    MiR's own state names go out verbatim in ``state``, and the platform can only infer a
+    status from its own canonical names, so leaving this unset renders the mission grey
+    for its entire run. It is always sent explicitly.
+
+    A running mission is never an error: it has not failed, and if the robot is paused,
+    e-stopped or faulted it is stuck, which is a warning.
+    """
+    if mission.get("finished") is not None:
+        return MISSION_STATUS_OK if mission["state"] == MISSION_STATE_DONE else MISSION_STATUS_ERROR
+    if robot_status.get("state_id") in _BLOCKED_STATE_IDS:
+        return MISSION_STATUS_WARNING
+    return MISSION_STATUS_OK
+
+
 # A substitution in a MiR action description, e.g. "%(position)s" or "%(register)d".
 _PLACEHOLDER = re.compile(r"%\((\w+)\)[a-z]")
 # MiR durations are "HH:MM:SS.ffffff".
@@ -245,6 +271,7 @@ class MirInorbitMissionTracking:
         self._mission_definition = None  # definition of the tracked mission, one fetch per entry
         self._tasks_tracker = None  # MirNativeMissionTasks for the tracked queue entry
         self.last_reported_tasks_signature = None
+        self.last_reported_status = None
 
     async def _get_action_definitions(self):
         """{action_type: definition}, fetched once and cached; {} (and a retry on the next
@@ -353,12 +380,14 @@ class MirInorbitMissionTracking:
         # Merge 'Abort' and 'Aborted' values into a single state
         if mission["state"] == MISSION_STATE_ABORT:
             mission["state"] = MISSION_STATE_ABORTED
+        mission_status = _mission_status(mission, status)
         tasks_signature = tracker.signature() if tracker is not None else None
         if (
             mission["id"] == self.last_reported_mission_id
             and mission["state"] == MISSION_STATE_EXECUTING
             and completed_percent == self.last_reported_mission_progress
             and tasks_signature == self.last_reported_tasks_signature
+            and mission_status == self.last_reported_status
         ):
             # Avoid flooding mission reports when nothing important has changed
             return
@@ -368,6 +397,7 @@ class MirInorbitMissionTracking:
             "inProgress": mission["state"] == MISSION_STATE_EXECUTING,
             "state": mission["state"],
             "startTs": self._safe_localize_timestamp(mission["started"]) * 1000,
+            "status": mission_status,
             "data": {
                 "Total Distance (m)": metrics.get("mir_robot_distance_moved_meters_total", "N/A"),
                 "Total Missions": mission["id"],
@@ -384,9 +414,11 @@ class MirInorbitMissionTracking:
             mission_values["data"]["Mission Steps"] = len(definition["actions"])
         if mission.get("finished") is not None:
             mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
-            mission_values["completedPercent"] = 1
-            mission_values["status"] = "OK" if mission["state"] == MISSION_STATE_DONE else "error"
-        elif completed_percent is not None:
+            # Only a mission that ran to the end is 100%. An abort at step 2 of 10 used to
+            # report 1.0, contradicting the task list in the same payload.
+            if mission["state"] == MISSION_STATE_DONE:
+                completed_percent = 1
+        if completed_percent is not None:
             mission_values["completedPercent"] = completed_percent
 
         self.logger.debug(f"Reporting mission: {mission_values}")
@@ -396,3 +428,4 @@ class MirInorbitMissionTracking:
         self.last_reported_mission_progress = completed_percent
         self.last_reported_mission_id = mission["id"]
         self.last_reported_tasks_signature = tasks_signature
+        self.last_reported_status = mission_status

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -111,6 +111,7 @@ class MirInorbitMissionTracking:
         self._position_names = {}  # {position guid: name}, kept for life
         self._mission_definition = None  # definition of the tracked mission, one fetch per entry
         self._tasks_tracker = None  # MirNativeMissionTasks for the tracked queue entry
+        self.last_reported_tasks_signature = None
 
     async def _get_action_names(self):
         """Action-type display names, fetched once and cached; {} (and a retry on the
@@ -219,49 +220,65 @@ class MirInorbitMissionTracking:
         if await self.mission_executor.has_active_mission():
             return
         mission = await self.get_current_mission()
-        if mission:
-            completed_percent = len(mission["actions"]) / len(mission["definition"]["actions"])
-            # Merge 'Abort' and 'Aborted' values into a single state
-            if mission["state"] == MISSION_STATE_ABORT:
-                mission["state"] = MISSION_STATE_ABORTED
-            if (
-                mission["id"] == self.last_reported_mission_id
-                and mission["state"] == MISSION_STATE_EXECUTING
-                and completed_percent == self.last_reported_mission_progress
-            ):
-                # Avoid flooding mission reports when nothing important has changed
-                return
-            mission_values = {
-                "missionId": mission["id"],
-                "inProgress": mission["state"] == MISSION_STATE_EXECUTING,
-                "state": mission["state"],
-                "label": mission["definition"]["name"],
-                "startTs": self._safe_localize_timestamp(mission["started"]) * 1000,
-                "data": {
-                    "Total Distance (m)": metrics.get(
-                        "mir_robot_distance_moved_meters_total", "N/A"
-                    ),
-                    "Mission Steps": len(mission["definition"]["actions"]),
-                    "Total Missions": mission["id"],
-                    "Robot Model": status["robot_model"],
-                    "Uptime (s)": status["uptime"],
-                    "Serial Number": status.get("serial_number", "N/A"),
-                    "Battery Time Remaning (s)": status.get("battery_time_remaining", "N/A"),
-                    "WiFi RSSI (dbm)": metrics.get("mir_robot_wifi_access_point_rssi_dbm", "N/A"),
-                },
-            }
-            if mission.get("finished") is not None:
-                mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
-                mission_values["completedPercent"] = 1
-                mission_values["status"] = (
-                    "OK" if mission["state"] == MISSION_STATE_DONE else "error"
-                )
-            else:
-                mission_values["completedPercent"] = completed_percent
-
-            self.logger.debug(f"Reporting mission: {mission_values}")
-            self.inorbit_sess.publish_key_values(
-                key_values={"mission_tracking": mission_values}, is_event=True
+        if not mission:
+            return
+        tracker = self._tasks_tracker
+        task_fields = {}
+        if tracker is not None:
+            await tracker.poll()
+            task_fields = tracker.report_fields()
+            completed_percent = task_fields.pop("completedPercent")
+        else:
+            # No tracker (mocked or degraded paths): count-based estimate as before.
+            completed_percent = min(
+                1.0,
+                len(mission.get("actions", [])) / max(1, len(mission["definition"]["actions"])),
             )
-            self.last_reported_mission_progress = completed_percent
-            self.last_reported_mission_id = mission["id"]
+        # Merge 'Abort' and 'Aborted' values into a single state
+        if mission["state"] == MISSION_STATE_ABORT:
+            mission["state"] = MISSION_STATE_ABORTED
+        tasks_signature = tracker.signature() if tracker is not None else None
+        if (
+            mission["id"] == self.last_reported_mission_id
+            and mission["state"] == MISSION_STATE_EXECUTING
+            and completed_percent == self.last_reported_mission_progress
+            and tasks_signature == self.last_reported_tasks_signature
+        ):
+            # Avoid flooding mission reports when nothing important has changed
+            return
+        mission_values = {
+            "missionId": mission["id"],
+            "inProgress": mission["state"] == MISSION_STATE_EXECUTING,
+            "state": mission["state"],
+            "label": mission["definition"]["name"],
+            "startTs": self._safe_localize_timestamp(mission["started"]) * 1000,
+            "data": {
+                "Total Distance (m)": metrics.get(
+                    "mir_robot_distance_moved_meters_total", "N/A"
+                ),
+                "Mission Steps": len(mission["definition"]["actions"]),
+                "Total Missions": mission["id"],
+                "Robot Model": status["robot_model"],
+                "Uptime (s)": status["uptime"],
+                "Serial Number": status.get("serial_number", "N/A"),
+                "Battery Time Remaning (s)": status.get("battery_time_remaining", "N/A"),
+                "WiFi RSSI (dbm)": metrics.get("mir_robot_wifi_access_point_rssi_dbm", "N/A"),
+            },
+            **task_fields,
+        }
+        if mission.get("finished") is not None:
+            mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
+            mission_values["completedPercent"] = 1
+            mission_values["status"] = (
+                "OK" if mission["state"] == MISSION_STATE_DONE else "error"
+            )
+        else:
+            mission_values["completedPercent"] = completed_percent
+
+        self.logger.debug(f"Reporting mission: {mission_values}")
+        self.inorbit_sess.publish_key_values(
+            key_values={"mission_tracking": mission_values}, is_event=True
+        )
+        self.last_reported_mission_progress = completed_percent
+        self.last_reported_mission_id = mission["id"]
+        self.last_reported_tasks_signature = tasks_signature

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -198,7 +198,8 @@ class MirInorbitMissionTracking:
         """Return the current mission, it's either executing or just ended.
 
         The queue entry is fetched every tick; the definition (with actions) once per
-        queue entry, when the per-action task tracker is also (re)built.
+        queue entry, when the per-action task tracker is also (re)built. Entries with no
+        ``mission_id`` have no definition and get ``None`` for it.
         """
         if self.executing_mission_id is None:
             self.executing_mission_id = await self.mir_api.get_executing_mission_id()
@@ -208,7 +209,11 @@ class MirInorbitMissionTracking:
             return None
         queue_id = self.executing_mission_id
         mission = await self.mir_api.get_mission_queue_entry(queue_id)
-        if self._mission_definition is None:
+        # Fleet-dispatched ActionLists carry no mission_id, and are the majority of the queue
+        # on a fleet-managed robot. There is no definition to fetch (GET /missions/None is a
+        # 400) and their queue actions have a null action_id, so they are reported without a
+        # task list rather than raising on every tick.
+        if mission.get("mission_id") and self._mission_definition is None:
             definition = await self.mir_api.get_mission_definition(mission["mission_id"])
             definition["actions"] = await self.mir_api.get_mission_actions(mission["mission_id"])
             self._mission_definition = definition
@@ -250,15 +255,14 @@ class MirInorbitMissionTracking:
         ):
             # Avoid flooding mission reports when nothing important has changed
             return
+        definition = mission["definition"]
         mission_values = {
             "missionId": mission["id"],
             "inProgress": mission["state"] == MISSION_STATE_EXECUTING,
             "state": mission["state"],
-            "label": mission["definition"]["name"],
             "startTs": self._safe_localize_timestamp(mission["started"]) * 1000,
             "data": {
                 "Total Distance (m)": metrics.get("mir_robot_distance_moved_meters_total", "N/A"),
-                "Mission Steps": len(mission["definition"]["actions"]),
                 "Total Missions": mission["id"],
                 "Robot Model": status["robot_model"],
                 "Uptime (s)": status["uptime"],
@@ -268,6 +272,9 @@ class MirInorbitMissionTracking:
             },
             **task_fields,
         }
+        if definition is not None:
+            mission_values["label"] = definition["name"]
+            mission_values["data"]["Mission Steps"] = len(definition["actions"])
         if mission.get("finished") is not None:
             mission_values["endTs"] = self._safe_localize_timestamp(mission["finished"]) * 1000
             mission_values["completedPercent"] = 1

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -21,25 +21,42 @@ MISSION_STATUS_OK = "OK"
 MISSION_STATUS_WARNING = "warning"
 MISSION_STATUS_ERROR = "error"
 
-# Robot state ids that stop a running mission making progress.
-_BLOCKED_STATE_IDS = frozenset({4, 10, 12})  # Pause, EmergencyStop, Error
+# States we report on top of MiR's own. MiR leaves the queue entry "Executing" whether the
+# robot is driving, paused or e-stopped, so a stalled mission is invisible in the queue
+# state alone and the robot state has to supply it.
+MISSION_STATE_PAUSED = "Paused"
+MISSION_STATE_EMERGENCY_STOP = "Emergency stop"
+MISSION_STATE_ERROR = "Error"
+
+# Robot state_id -> the mission state it implies while the queue entry is still executing.
+# Only 4 is corroborated (it is MirApiV2.SetStateId.PAUSE); the other two are unobserved so
+# far, and an unknown id simply leaves the mission executing.
+_STATE_BY_ROBOT_STATE_ID = {
+    4: MISSION_STATE_PAUSED,
+    10: MISSION_STATE_EMERGENCY_STOP,
+    12: MISSION_STATE_ERROR,
+}
+
+# Every reported state maps to exactly one status. Unlisted MiR states are reported as OK.
+_STATUS_BY_STATE = {
+    MISSION_STATE_EXECUTING: MISSION_STATUS_OK,
+    MISSION_STATE_DONE: MISSION_STATUS_OK,
+    MISSION_STATE_PAUSED: MISSION_STATUS_WARNING,
+    MISSION_STATE_EMERGENCY_STOP: MISSION_STATUS_WARNING,
+    MISSION_STATE_ERROR: MISSION_STATUS_ERROR,
+    MISSION_STATE_ABORTED: MISSION_STATUS_ERROR,
+}
 
 
-def _mission_status(mission, robot_status):
-    """InOrbit status for a MiR queue entry: OK, warning or error.
+def _reported_state(mir_state, robot_status):
+    """Mission state to report: MiR's queue state, refined by the robot's own state.
 
-    MiR's own state names go out verbatim in ``state``, and the platform can only infer a
-    status from its own canonical names, so leaving this unset renders the mission grey
-    for its entire run. It is always sent explicitly.
-
-    A running mission is never an error: it has not failed, and if the robot is paused,
-    e-stopped or faulted it is stuck, which is a warning.
+    Only a still-executing entry can be refined; once the entry reaches a final state that
+    is the whole story.
     """
-    if mission.get("finished") is not None:
-        return MISSION_STATUS_OK if mission["state"] == MISSION_STATE_DONE else MISSION_STATUS_ERROR
-    if robot_status.get("state_id") in _BLOCKED_STATE_IDS:
-        return MISSION_STATUS_WARNING
-    return MISSION_STATUS_OK
+    if mir_state != MISSION_STATE_EXECUTING:
+        return mir_state
+    return _STATE_BY_ROBOT_STATE_ID.get(robot_status.get("state_id"), MISSION_STATE_EXECUTING)
 
 
 # A substitution in a MiR action description, e.g. "%(position)s" or "%(register)d".
@@ -271,7 +288,7 @@ class MirInorbitMissionTracking:
         self._mission_definition = None  # definition of the tracked mission, one fetch per entry
         self._tasks_tracker = None  # MirNativeMissionTasks for the tracked queue entry
         self.last_reported_tasks_signature = None
-        self.last_reported_status = None
+        self.last_reported_state = None
         self._finished_mission_id = None  # last queue entry seen through to a final state
 
     async def _get_action_definitions(self):
@@ -397,22 +414,27 @@ class MirInorbitMissionTracking:
         # Merge 'Abort' and 'Aborted' values into a single state
         if mission["state"] == MISSION_STATE_ABORT:
             mission["state"] = MISSION_STATE_ABORTED
-        mission_status = _mission_status(mission, status)
+        # A paused mission is still open, so inProgress follows MiR's queue state, not the
+        # reported one. Reporting it false would make the platform stamp an end time and
+        # close the mission.
+        in_progress = mission["state"] == MISSION_STATE_EXECUTING
+        reported_state = _reported_state(mission["state"], status)
+        mission_status = _STATUS_BY_STATE.get(reported_state, MISSION_STATUS_OK)
         tasks_signature = tracker.signature() if tracker is not None else None
         if (
             mission["id"] == self.last_reported_mission_id
-            and mission["state"] == MISSION_STATE_EXECUTING
+            and in_progress
             and completed_percent == self.last_reported_mission_progress
             and tasks_signature == self.last_reported_tasks_signature
-            and mission_status == self.last_reported_status
+            and reported_state == self.last_reported_state
         ):
             # Avoid flooding mission reports when nothing important has changed
             return
         definition = mission["definition"]
         mission_values = {
             "missionId": mission["id"],
-            "inProgress": mission["state"] == MISSION_STATE_EXECUTING,
-            "state": mission["state"],
+            "inProgress": in_progress,
+            "state": reported_state,
             "startTs": self._safe_localize_timestamp(mission["started"]) * 1000,
             "status": mission_status,
             "data": {
@@ -445,4 +467,4 @@ class MirInorbitMissionTracking:
         self.last_reported_mission_progress = completed_percent
         self.last_reported_mission_id = mission["id"]
         self.last_reported_tasks_signature = tasks_signature
-        self.last_reported_status = mission_status
+        self.last_reported_state = reported_state

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -272,6 +272,7 @@ class MirInorbitMissionTracking:
         self._tasks_tracker = None  # MirNativeMissionTasks for the tracked queue entry
         self.last_reported_tasks_signature = None
         self.last_reported_status = None
+        self._finished_mission_id = None  # last queue entry seen through to a final state
 
     async def _get_action_definitions(self):
         """{action_type: definition}, fetched once and cached; {} (and a retry on the next
@@ -328,7 +329,22 @@ class MirInorbitMissionTracking:
             # Return current time as fallback
             return datetime.now().timestamp()
 
-    async def get_current_mission(self):
+    async def _find_executing_mission_id(self, robot_status):
+        """Queue id of the mission the robot is running, or None.
+
+        ``/status`` carries it and the connector already fetches ``/status`` every tick,
+        so this normally costs nothing at all. The queue endpoint is only consulted when
+        the field is missing.
+        """
+        if robot_status and "mission_queue_id" in robot_status:
+            queue_id = robot_status["mission_queue_id"]
+        else:
+            queue_id = await self.mir_api.get_executing_mission_id()
+        # The field clears when the mission ends, but if a firmware ever left it set we
+        # would re-adopt an entry we have already finished with and republish it forever.
+        return None if queue_id == self._finished_mission_id else queue_id
+
+    async def get_current_mission(self, robot_status=None):
         """Return the current mission, it's either executing or just ended.
 
         The queue entry is fetched every tick; the definition (with actions) once per
@@ -336,7 +352,7 @@ class MirInorbitMissionTracking:
         ``mission_id`` have no definition and get ``None`` for it.
         """
         if self.executing_mission_id is None:
-            self.executing_mission_id = await self.mir_api.get_executing_mission_id()
+            self.executing_mission_id = await self._find_executing_mission_id(robot_status)
             self._mission_definition = None
             self._tasks_tracker = None
         if not self.executing_mission_id:
@@ -360,6 +376,7 @@ class MirInorbitMissionTracking:
             # executing mission or None.
             # Note that the current call in this case returns the just finished mission
             self.executing_mission_id = None
+            self._finished_mission_id = queue_id
         return mission
 
     async def report_mission(self, status, metrics):
@@ -367,7 +384,7 @@ class MirInorbitMissionTracking:
         # mission tracking. Skip robot-side polling to avoid duplicate reports.
         if await self.mission_executor.has_active_mission():
             return
-        mission = await self.get_current_mission()
+        mission = await self.get_current_mission(status)
         if not mission:
             return
         tracker = self._tasks_tracker

--- a/mir_connector/inorbit_mir_connector/src/mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/src/mission_tracking.py
@@ -6,6 +6,8 @@ import logging
 from datetime import datetime
 from inorbit_edge.missions import MISSION_STATE_EXECUTING, MISSION_STATE_ABORTED
 
+from .mission.translator import _SCOPE_BEARING_DENIED
+
 # Mission states
 MISSION_STATE_DONE = "Done"
 MISSION_STATE_ABORT = "Abort"
@@ -16,6 +18,46 @@ POSITION_PARAM_PHRASES = {"position": "to", "marker": "at"}
 
 # Max detail GETs issued in a single poll tick.
 _MAX_DETAIL_FETCHES_PER_POLL = 25
+
+
+def _execution_order(actions):
+    """Mission definition actions in the order the robot runs them.
+
+    ``GET /missions/{id}/actions`` returns them in no useful order, and ``priority`` is
+    not a global rank: it orders siblings within one scope only, and each scope numbers
+    its own children (two actions in different scopes routinely share a priority). The
+    list is a tree, linked by ``scope_reference`` -> the guid of a *parameter* of the
+    containing action, null at the top level. So this is a DFS pre-order, which is also
+    what an operator reads top to bottom.
+
+    No list of scope-bearing action types is needed: a parameter guid that something
+    points at is, by definition, a scope.
+    """
+    children = {}
+    for action in actions:
+        children.setdefault(action.get("scope_reference"), []).append(action)
+    for siblings in children.values():
+        siblings.sort(key=lambda a: a.get("priority") or 0)
+    ordered = []
+    # Guards against a parameter guid that loops back to an enclosing scope. Malformed
+    # input would otherwise hang the poll loop; None is seeded because it is the root key
+    # and an unset parameter guid must not be read as "nested at the top level".
+    walked = {None}
+
+    def walk(scope):
+        for action in children.get(scope, []):
+            ordered.append(action)
+            for param in action.get("parameters") or []:
+                nested = param.get("guid")
+                if nested in children and nested not in walked:
+                    walked.add(nested)
+                    walk(nested)
+
+    walk(None)
+    # Anything unreachable from the root (a scope_reference we never saw as a parameter)
+    # is appended rather than dropped, so a task is never silently lost.
+    placed = {id(a) for a in ordered}
+    return ordered + [a for a in actions if id(a) not in placed]
 
 
 def _action_outcome(detail):
@@ -171,13 +213,18 @@ class MirInorbitMissionTracking:
         return label
 
     async def _build_tasks(self, actions):
-        """Ordered {guid: task dict} from the mission definition actions (flat list,
-        including actions nested in scopes)."""
+        """{guid: task dict} in execution order, one task per real mission step.
+
+        Scope-bearing actions (loop, if, try_catch, ...) are containers, not steps: they
+        are what the nested actions hang off, they need not ever report finished, and
+        while their body runs they would show as a second task in progress. Their
+        children stay, in place.
+        """
         action_names = await self._get_action_names()
         tasks = {}
-        for action in actions:
+        for action in _execution_order(actions):
             guid = action.get("guid")
-            if not guid:
+            if not guid or action.get("action_type") in _SCOPE_BEARING_DENIED:
                 continue
             tasks[guid] = {
                 "taskId": guid,

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -200,6 +200,28 @@ async def test_get_action_definitions(mir_api, httpx_mock):
 
 
 @pytest.mark.asyncio
+async def test_get_mission_actions_requests_scope_reference(mir_api, httpx_mock):
+    """scope_reference is not in the default response and must be whitelisted.
+
+    Without it every action looks top-level, the nesting is invisible and the task list
+    silently falls back to the API's (meaningless) response order. Nothing else would fail
+    loudly, so the query string itself is the assertion.
+    """
+    actions = [
+        {"guid": "g1", "action_type": "wait", "priority": 12, "scope_reference": None},
+    ]
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"{mir_api.mir_api_base_url}/missions/m1/actions"
+            "?whitelist=guid%2Caction_type%2Cpriority%2Cscope_reference%2Cparameters"
+        ),
+        json=actions,
+    )
+    assert await mir_api.get_mission_actions("m1") == actions
+
+
+@pytest.mark.asyncio
 async def test_get_position(mir_api, httpx_mock):
     position = {"guid": "pos-guid-1", "name": "Warehouse-1", "type_id": 0}
     httpx_mock.add_response(

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -61,9 +61,9 @@ async def test_http_error_logs_response_body(mir_api, httpx_mock, caplog):
 async def test_get_executing_mission_id(mir_api, httpx_mock):
     """Reads only the tail of the queue, newest first.
 
-    Unbounded, this endpoint returns every entry the robot has ever run (2 MB on ours).
-    MiR silently ignores params it does not know, so limit and sort_by must travel
-    together or we would read the oldest entries instead of the newest.
+    Unbounded, this endpoint returns every entry the robot has ever run. MiR ignores
+    params it does not know, so limit and sort_by must travel together: limit alone
+    would return the oldest entries.
     """
     missions = [
         {"id": 2, "state": "Aborted"},

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -187,3 +187,22 @@ mir_robot_wifi_access_point_frequency_hertz 0.0
     metrics = await mir_api.get_metrics()
 
     assert DeepDiff(expected_output, metrics) == {}
+
+
+@pytest.mark.asyncio
+async def test_get_action_definitions(mir_api, httpx_mock):
+    defs = [
+        {"action_type": "move", "name": "Move", "description": "Move to a position"},
+        {"action_type": "docking", "name": "Docking", "description": "Dock to a marker"},
+    ]
+    httpx_mock.add_response(method="GET", url=f"{mir_api.mir_api_base_url}/actions", json=defs)
+    assert await mir_api.get_action_definitions() == defs
+
+
+@pytest.mark.asyncio
+async def test_get_position(mir_api, httpx_mock):
+    position = {"guid": "pos-guid-1", "name": "Warehouse-1", "type_id": 0}
+    httpx_mock.add_response(
+        method="GET", url=f"{mir_api.mir_api_base_url}/positions/pos-guid-1", json=position
+    )
+    assert await mir_api.get_position("pos-guid-1") == position

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -190,12 +190,28 @@ mir_robot_wifi_access_point_frequency_hertz 0.0
 
 
 @pytest.mark.asyncio
-async def test_get_action_definitions(mir_api, httpx_mock):
+async def test_get_action_definitions_requests_label_metadata(mir_api, httpx_mock):
+    """Unwhitelisted, GET /actions returns only action_type and url.
+
+    Without the whitelist there is no name, no description template and no parameter
+    metadata, and every task label silently degrades to the raw action type.
+    """
     defs = [
-        {"action_type": "move", "name": "Move", "description": "Move to a position"},
-        {"action_type": "docking", "name": "Docking", "description": "Dock to a marker"},
+        {
+            "action_type": "move",
+            "name": "Move",
+            "description": "Move to %(position)s",
+            "parameters": [{"id": "position", "type": "Reference", "constraints": {}}],
+        },
     ]
-    httpx_mock.add_response(method="GET", url=f"{mir_api.mir_api_base_url}/actions", json=defs)
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"{mir_api.mir_api_base_url}/actions"
+            "?whitelist=action_type%2Cname%2Cdescription%2Cparameters"
+        ),
+        json=defs,
+    )
     assert await mir_api.get_action_definitions() == defs
 
 
@@ -219,12 +235,3 @@ async def test_get_mission_actions_requests_scope_reference(mir_api, httpx_mock)
         json=actions,
     )
     assert await mir_api.get_mission_actions("m1") == actions
-
-
-@pytest.mark.asyncio
-async def test_get_position(mir_api, httpx_mock):
-    position = {"guid": "pos-guid-1", "name": "Warehouse-1", "type_id": 0}
-    httpx_mock.add_response(
-        method="GET", url=f"{mir_api.mir_api_base_url}/positions/pos-guid-1", json=position
-    )
-    assert await mir_api.get_position("pos-guid-1") == position

--- a/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mir_api_v2.py
@@ -59,13 +59,24 @@ async def test_http_error_logs_response_body(mir_api, httpx_mock, caplog):
 
 @pytest.mark.asyncio
 async def test_get_executing_mission_id(mir_api, httpx_mock):
+    """Reads only the tail of the queue, newest first.
+
+    Unbounded, this endpoint returns every entry the robot has ever run (2 MB on ours).
+    MiR silently ignores params it does not know, so limit and sort_by must travel
+    together or we would read the oldest entries instead of the newest.
+    """
     missions = [
         {"id": 2, "state": "Aborted"},
         {"id": 1, "state": "Executing"},
         {"id": 3, "state": "Completed"},
     ]
     httpx_mock.add_response(
-        method="GET", url=f"{mir_api.mir_api_base_url}/mission_queue", json=missions
+        method="GET",
+        url=(
+            f"{mir_api.mir_api_base_url}/mission_queue"
+            "?limit=20&sort_by=id%2Cdesc&whitelist=id%2Cstate"
+        ),
+        json=missions,
     )
     assert await mir_api.get_executing_mission_id() == 1
 

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -70,6 +70,42 @@ async def test_get_current_mission(mission_tracking):
 
 
 @pytest.mark.asyncio
+async def test_executing_mission_id_comes_from_status(mission_tracking):
+    """/status already carries mission_queue_id and is already fetched every tick.
+
+    The queue endpoint is unbounded (2 MB on a robot with history) and polling it once a
+    second cannot keep up, so it is only a fallback for when the field is absent.
+    """
+    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(side_effect=AssertionError)
+    assert await mission_tracking._find_executing_mission_id({"mission_queue_id": 7}) == 7
+    # Idle robot: the field is present and null, which is an answer, not a gap.
+    assert await mission_tracking._find_executing_mission_id({"mission_queue_id": None}) is None
+
+    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=9)
+    assert await mission_tracking._find_executing_mission_id({}) == 9
+    assert await mission_tracking._find_executing_mission_id(None) == 9
+
+
+@pytest.mark.asyncio
+async def test_finished_mission_is_not_readopted(mission_tracking):
+    # mission_queue_id clears when the mission ends, but if a firmware left it set we would
+    # re-adopt the finished entry and republish it on every tick.
+    entry = {
+        "state": "Done",
+        "id": 5,
+        "mission_id": None,
+        "started": "2026-08-10T10:00:00",
+        "finished": "2026-08-10T10:01:00",
+    }
+    mission_tracking.mir_api.get_mission_queue_entry = AsyncMock(return_value=dict(entry))
+    status = {"mission_queue_id": 5}
+
+    assert (await mission_tracking.get_current_mission(status))["id"] == 5
+    assert mission_tracking.executing_mission_id is None
+    assert await mission_tracking.get_current_mission(status) is None
+
+
+@pytest.mark.asyncio
 async def test_fleet_action_list_without_mission_id(
     mission_tracking, sample_metrics_data, sample_status_data
 ):
@@ -78,7 +114,8 @@ async def test_fleet_action_list_without_mission_id(
     GET /missions/None is a 400, which used to raise out of every tick without ever clearing
     executing_mission_id, wedging mission tracking for the life of the process.
     """
-    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=42)
+    status = {**sample_status_data, "mission_queue_id": 42}
+    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(side_effect=AssertionError)
     mission_tracking.mir_api.get_mission_queue_entry = AsyncMock(
         return_value={
             "state": "Executing",
@@ -91,7 +128,7 @@ async def test_fleet_action_list_without_mission_id(
     mission_tracking.mir_api.get_mission_definition = AsyncMock(side_effect=AssertionError)
     mission_tracking.mir_api.get_mission_actions = AsyncMock(side_effect=AssertionError)
 
-    await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
+    await mission_tracking.report_mission(status, sample_metrics_data)
 
     reported = mission_tracking.inorbit_sess.publish_key_values.call_args.kwargs["key_values"][
         "mission_tracking"
@@ -105,7 +142,7 @@ async def test_fleet_action_list_without_mission_id(
     assert mission_tracking._tasks_tracker is None
 
     # The next tick still tracks the same entry and still does not fetch a definition.
-    await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
+    await mission_tracking.report_mission(status, sample_metrics_data)
     assert mission_tracking.executing_mission_id == 42
 
 

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -88,8 +88,8 @@ async def test_executing_mission_id_comes_from_status(mission_tracking):
 
 @pytest.mark.asyncio
 async def test_finished_mission_is_not_readopted(mission_tracking):
-    # mission_queue_id clears when the mission ends, but if a firmware left it set we would
-    # re-adopt the finished entry and republish it on every tick.
+    # mission_queue_id clears when a mission ends; a firmware that left it set would make
+    # the finished entry republish on every tick.
     entry = {
         "state": "Done",
         "id": 5,
@@ -111,8 +111,8 @@ async def test_fleet_action_list_without_mission_id(
 ):
     """Fleet-dispatched ActionLists have mission_id None: no definition, no tasks, no crash.
 
-    GET /missions/None is a 400, which used to raise out of every tick without ever clearing
-    executing_mission_id, wedging mission tracking for the life of the process.
+    GET /missions/None is a 400, and executing_mission_id is only reassigned when it is
+    None, so a raise here leaves the entry pinned and stops tracking for good.
     """
     status = {**sample_status_data, "mission_queue_id": 42}
     mission_tracking.mir_api.get_executing_mission_id = AsyncMock(side_effect=AssertionError)
@@ -200,9 +200,8 @@ async def test_report_mission(
         }
     }
 
-    # get_current_mission is mocked out, so no task tracker exists and there is no progress
-    # to report. Omitting completedPercent is the point: the previous count-based estimate
-    # read the queue entry's "actions", which is a URL string, and always yielded 1.0.
+    # get_current_mission is mocked out, so there is no task tracker and no progress to
+    # report: completedPercent is omitted rather than estimated.
     assert DeepDiff(reported_mission, should_be) == {}
 
 

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -27,19 +27,46 @@ def mission_tracking():
 
 @pytest.mark.asyncio
 async def test_get_current_mission(mission_tracking):
-    # Only missions with "Executing" state should be stored in executing_mission_id
     assert mission_tracking.executing_mission_id is None
-    dummy_data = {"state": "Executing"}
-    id = 1
-    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=id)
-    mission_tracking.mir_api.get_mission = AsyncMock(return_value=dummy_data)
-    assert await mission_tracking.get_current_mission() == dummy_data
-    assert mission_tracking.executing_mission_id == 1
+    entry = {"state": "Executing", "id": 1, "mission_id": "def-guid", "finished": None}
+    definition = {"guid": "def-guid", "name": "Charge"}
+    def_actions = [
+        {"guid": "a1", "action_type": "charging", "parameters": [], "mission_id": "def-guid"}
+    ]
+    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=1)
+    mission_tracking.mir_api.get_mission_queue_entry = AsyncMock(return_value=dict(entry))
+    mission_tracking.mir_api.get_mission_definition = AsyncMock(return_value=dict(definition))
+    mission_tracking.mir_api.get_mission_actions = AsyncMock(return_value=def_actions)
+    mission_tracking.mir_api.get_action_definitions = AsyncMock(
+        return_value=[{"action_type": "charging", "name": "Charging"}]
+    )
 
-    dummy_data = {"state": "Completed"}
-    mission_tracking.mir_api.get_mission = AsyncMock(return_value=dummy_data)
-    assert await mission_tracking.get_current_mission() == dummy_data
+    mission = await mission_tracking.get_current_mission()
+    assert mission["id"] == 1
+    assert mission["definition"]["name"] == "Charge"
+    assert mission["definition"]["actions"] == def_actions
+    assert mission_tracking.executing_mission_id == 1
+    assert mission_tracking._tasks_tracker is not None
+
+    # The definition is cached per queue entry: a second tick refetches only the entry.
+    await mission_tracking.get_current_mission()
+    assert mission_tracking.mir_api.get_mission_definition.await_count == 1
+    assert mission_tracking.mir_api.get_mission_actions.await_count == 1
+    assert mission_tracking.mir_api.get_mission_queue_entry.await_count == 2
+
+    # A non-executing state clears executing_mission_id but still returns the mission
+    # (the just-finished mission is reported exactly once).
+    mission_tracking.mir_api.get_mission_queue_entry = AsyncMock(
+        return_value={**entry, "state": "Done", "finished": "2026-08-10T10:00:00"}
+    )
+    mission = await mission_tracking.get_current_mission()
+    assert mission["state"] == "Done"
     assert mission_tracking.executing_mission_id is None
+
+    # With no next executing mission, the next tick returns None and drops the tracker.
+    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=None)
+    assert await mission_tracking.get_current_mission() is None
+    assert mission_tracking._tasks_tracker is None
 
 
 @pytest.mark.asyncio

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -147,6 +147,7 @@ async def test_report_mission(
             "missionId": 14026,
             "inProgress": True,
             "state": "Executing",
+            "status": "OK",
             "label": "Charge",
             "startTs": 1701946471000.0,
             "data": {

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -70,6 +70,46 @@ async def test_get_current_mission(mission_tracking):
 
 
 @pytest.mark.asyncio
+async def test_fleet_action_list_without_mission_id(
+    mission_tracking, sample_metrics_data, sample_status_data
+):
+    """Fleet-dispatched ActionLists have mission_id None: no definition, no tasks, no crash.
+
+    GET /missions/None is a 400, which used to raise out of every tick without ever clearing
+    executing_mission_id, wedging mission tracking for the life of the process.
+    """
+    mission_tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=42)
+    mission_tracking.mir_api.get_mission_queue_entry = AsyncMock(
+        return_value={
+            "state": "Executing",
+            "id": 42,
+            "mission_id": None,
+            "started": "2026-08-10T10:00:00",
+            "finished": None,
+        }
+    )
+    mission_tracking.mir_api.get_mission_definition = AsyncMock(side_effect=AssertionError)
+    mission_tracking.mir_api.get_mission_actions = AsyncMock(side_effect=AssertionError)
+
+    await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
+
+    reported = mission_tracking.inorbit_sess.publish_key_values.call_args.kwargs["key_values"][
+        "mission_tracking"
+    ]
+    assert reported["missionId"] == 42
+    assert reported["inProgress"] is True
+    # Definition-derived fields are absent rather than fabricated.
+    assert "label" not in reported
+    assert "tasks" not in reported
+    assert "Mission Steps" not in reported["data"]
+    assert mission_tracking._tasks_tracker is None
+
+    # The next tick still tracks the same entry and still does not fetch a definition.
+    await mission_tracking.report_mission(sample_status_data, sample_metrics_data)
+    assert mission_tracking.executing_mission_id == 42
+
+
+@pytest.mark.asyncio
 async def test_skips_reporting_while_edge_executor_busy(
     mission_tracking, sample_metrics_data, sample_status_data, sample_mir_mission_data
 ):

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking.py
@@ -119,10 +119,12 @@ async def test_report_mission(
                 "Battery Time Remaning (s)": 89725,
                 "WiFi RSSI (dbm)": -46.0,
             },
-            "completedPercent": 1.0,
         }
     }
 
+    # get_current_mission is mocked out, so no task tracker exists and there is no progress
+    # to report. Omitting completedPercent is the point: the previous count-based estimate
+    # read the queue entry's "actions", which is a URL string, and always yielded 1.0.
     assert DeepDiff(reported_mission, should_be) == {}
 
 

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -93,7 +93,7 @@ def test_execution_order_keeps_nested_actions_inside_their_scope():
     ordered = [a["guid"] for a in _execution_order(SCOPED)]
     assert ordered == ["a-if", "a-throw", "a-fields", "a-load", "a-footprint", "a-relmove"]
     # A global sort by priority hoists the nested load_mission out of its scope, above the
-    # top-level action that contains it. That is the trap this function exists to avoid.
+    # top-level action that contains it.
     naive = [a["guid"] for a in sorted(SCOPED, key=lambda a: a["priority"])]
     assert naive.index("a-load") < naive.index("a-fields")
     assert ordered.index("a-load") > ordered.index("a-fields")

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -21,14 +21,19 @@ def make_tasks(*guids):
     }
 
 
-def make_api(queue_actions=None, details=None):
-    """details: {int_id: (action_id, finished_or_None)}"""
+def make_api(queue_actions=None, details=None, states=None):
+    """details: {int_id: (action_id, finished_or_None)}; states: {int_id: state} (default "").
+
+    MiR reports a successful action with an empty state and a failed one with "Failed" or
+    "Aborted"; both carry a `finished` timestamp.
+    """
     api = MagicMock()
     api.get_mission_queue_actions = AsyncMock(return_value=queue_actions or [])
 
     async def get_detail(queue_id, int_id):
         action_id, finished = details[int_id]
-        return {"id": int_id, "action_id": action_id, "finished": finished, "state": ""}
+        state = (states or {}).get(int_id, "")
+        return {"id": int_id, "action_id": action_id, "finished": finished, "state": state}
 
     api.get_mission_queue_action = AsyncMock(side_effect=get_detail)
     return api
@@ -54,6 +59,41 @@ async def test_progresses_tasks_from_queue_actions():
     assert by_id["g3"]["inProgress"] is False and by_id["g3"]["completed"] is False
     assert fields["currentTaskId"] == "g2"
     assert fields["completedPercent"] == pytest.approx(1 / 3)
+
+
+@pytest.mark.asyncio
+async def test_failed_action_is_not_reported_completed():
+    # A failed action carries a `finished` timestamp just like a successful one; only the
+    # non-empty state distinguishes them. Reporting it completed put a green checkmark on the
+    # step that broke the mission.
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}, {"id": 2, "url": "u"}],
+        details={1: ("g1", "2026-08-10T10:00:00"), 2: ("g2", "2026-08-10T10:00:05")},
+        states={2: "Failed"},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1", "g2"))
+    await tracker.poll()
+    fields = tracker.report_fields()
+    by_id = {t["taskId"]: t for t in fields["tasks"]}
+    assert by_id["g1"]["completed"] is True
+    # A failed action is neither completed nor still running, and is not the current task.
+    assert by_id["g2"]["completed"] is False
+    assert by_id["g2"]["inProgress"] is False
+    assert "currentTaskId" not in fields
+    assert fields["completedPercent"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_aborted_action_is_not_reported_completed():
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}],
+        details={1: ("g1", "2026-08-10T10:00:00")},
+        states={1: "Aborted"},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1"))
+    await tracker.poll()
+    task = tracker.report_fields()["tasks"][0]
+    assert task["completed"] is False and task["inProgress"] is False
 
 
 @pytest.mark.asyncio

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -11,7 +11,9 @@ from inorbit_mir_connector.src.mir_api import MirApiV2
 from inorbit_mir_connector.src.mission_tracking import (
     MirInorbitMissionTracking,
     MirNativeMissionTasks,
+    _STATUS_BY_STATE,
     _execution_order,
+    _reported_state,
 )
 
 # Real GET /missions/{id}/actions?whitelist=...,scope_reference payloads, trimmed to the
@@ -515,24 +517,50 @@ async def test_report_mission_sends_status_while_executing():
     assert report["status"] == "OK"
 
 
+def test_state_maps_to_exactly_one_status():
+    # The point of the mapping: a state name means one thing. "Executing" is always OK; if
+    # the robot is blocked the state itself changes, rather than one state carrying two
+    # different statuses.
+    assert _STATUS_BY_STATE == {
+        "Executing": "OK",
+        "Done": "OK",
+        "Paused": "warning",
+        "Emergency stop": "warning",
+        "Error": "error",
+        "Aborted": "error",
+    }
+
+
+def test_reported_state_refines_only_a_running_mission():
+    assert _reported_state("Executing", {"state_id": 3}) == "Executing"
+    assert _reported_state("Executing", {"state_id": 4}) == "Paused"
+    assert _reported_state("Executing", {}) == "Executing"
+    # A finished entry is the whole story; the robot being idle afterwards says nothing.
+    assert _reported_state("Done", {"state_id": 4}) == "Done"
+    assert _reported_state("Aborted", {"state_id": 4}) == "Aborted"
+
+
 @pytest.mark.asyncio
-async def test_report_mission_warns_while_robot_is_blocked():
-    # Paused (4), emergency stop (10) and error (12) all stop the mission progressing. The
-    # mission has not failed, so it is a warning rather than an error.
-    for state_id in (4, 10, 12):
+async def test_report_mission_state_changes_when_robot_is_blocked():
+    # MiR leaves the queue entry "Executing" while the robot is paused, so the state has to
+    # come from the robot. The mission stays in progress: reporting inProgress false would
+    # make the platform stamp an end time and close it.
+    blocked = ((4, "Paused", "warning"), (10, "Emergency stop", "warning"), (12, "Error", "error"))
+    for state_id, state, expected_status in blocked:
         tracking = make_tracking()
         wire_mission(tracking, [def_action("g1")])
         tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
         await tracking.report_mission({**STATUS, "state_id": state_id}, {})
         report = published(tracking)[-1]
-        assert report["status"] == "warning", state_id
-        assert report["inProgress"] is True
+        assert report["state"] == state, state_id
+        assert report["status"] == expected_status, state_id
+        assert report["inProgress"] is True, state_id
 
 
 @pytest.mark.asyncio
-async def test_report_mission_republishes_when_status_changes():
-    # Nothing else changes when the robot pauses, so without status in the dedup key the
-    # warning would never reach the platform.
+async def test_report_mission_republishes_when_state_changes():
+    # Nothing MiR reports changes when the robot pauses, so without the reported state in
+    # the dedup key the pause would never reach the platform.
     tracking = make_tracking()
     wire_mission(tracking, [def_action("g1")])
     tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
@@ -540,7 +568,9 @@ async def test_report_mission_republishes_when_status_changes():
     await tracking.report_mission(STATUS, {})
     assert len(published(tracking)) == 1  # unchanged, deduplicated
     await tracking.report_mission({**STATUS, "state_id": 4}, {})
-    assert [r["status"] for r in published(tracking)] == ["OK", "warning"]
+    await tracking.report_mission(STATUS, {})  # resumed
+    assert [r["state"] for r in published(tracking)] == ["Executing", "Paused", "Executing"]
+    assert [r["status"] for r in published(tracking)] == ["OK", "warning", "OK"]
 
 
 @pytest.mark.asyncio

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -226,3 +226,102 @@ async def test_action_definitions_failure_uses_raw_types_and_retries():
     tracking.mir_api.get_action_definitions = AsyncMock(return_value=ACTION_DEFS)
     tasks = await tracking._build_tasks([def_action("g2", "move")])
     assert tasks["g2"]["label"] == "Move"
+
+
+def wire_mission(tracking, def_actions, entry_state="Executing", finished=None):
+    """Wire mir_api mocks for one native mission (queue id 7)."""
+    entry = {
+        "state": entry_state,
+        "id": 7,
+        "mission_id": "def-guid",
+        "started": "2026-08-10T10:00:00",
+        "finished": finished,
+    }
+    tracking.mir_api.get_executing_mission_id = AsyncMock(return_value=7)
+    tracking.mir_api.get_mission_queue_entry = AsyncMock(return_value=dict(entry))
+    tracking.mir_api.get_mission_definition = AsyncMock(
+        return_value={"guid": "def-guid", "name": "Patrol"}
+    )
+    tracking.mir_api.get_mission_actions = AsyncMock(return_value=def_actions)
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
+    tracking.mir_api.get_mission_queue_action = AsyncMock()
+
+
+def published(tracking):
+    calls = tracking.inorbit_sess.publish_key_values.call_args_list
+    return [c.kwargs["key_values"]["mission_tracking"] for c in calls]
+
+
+STATUS = {"robot_model": "MiR250", "uptime": 10, "serial_number": "s1"}
+
+
+@pytest.mark.asyncio
+async def test_report_mission_publishes_tasks_and_current_task():
+    tracking = make_tracking()
+    wire_mission(tracking, [def_action("g1"), def_action("g2")])
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[{"id": 1, "url": "u"}])
+    tracking.mir_api.get_mission_queue_action = AsyncMock(
+        return_value={"id": 1, "action_id": "g1", "finished": None}
+    )
+    await tracking.report_mission(STATUS, {})
+    report = published(tracking)[-1]
+    assert report["currentTaskId"] == "g1"
+    assert [t["taskId"] for t in report["tasks"]] == ["g1", "g2"]
+    assert report["tasks"][0]["inProgress"] is True
+    assert report["completedPercent"] == 0
+    assert report["inProgress"] is True and report["state"] == "Executing"
+    assert report["label"] == "Patrol"
+
+
+@pytest.mark.asyncio
+async def test_report_mission_percent_counts_completed_tasks():
+    tracking = make_tracking()
+    wire_mission(tracking, [def_action("g1"), def_action("g2")])
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[{"id": 1, "url": "u"}])
+    tracking.mir_api.get_mission_queue_action = AsyncMock(
+        return_value={"id": 1, "action_id": "g1", "finished": "2026-08-10T10:01:00"}
+    )
+    await tracking.report_mission(STATUS, {})
+    assert published(tracking)[-1]["completedPercent"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_report_mission_dedupes_until_task_state_changes():
+    tracking = make_tracking()
+    wire_mission(tracking, [def_action("g1"), def_action("g2")])
+    await tracking.report_mission(STATUS, {})
+    await tracking.report_mission(STATUS, {})
+    assert len(published(tracking)) == 1  # no change, no republish
+
+    # g1 starts: task transition must republish even though percent is still 0.
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[{"id": 1, "url": "u"}])
+    tracking.mir_api.get_mission_queue_action = AsyncMock(
+        return_value={"id": 1, "action_id": "g1", "finished": None}
+    )
+    await tracking.report_mission(STATUS, {})
+    assert len(published(tracking)) == 2
+    assert published(tracking)[-1]["currentTaskId"] == "g1"
+
+
+@pytest.mark.asyncio
+async def test_report_mission_done_completes_observed_only():
+    # Mission with an untaken if-branch action (g2 never appears in queue actions).
+    tracking = make_tracking()
+    wire_mission(
+        tracking,
+        [def_action("g1"), def_action("g2")],
+        entry_state="Done",
+        finished="2026-08-10T10:05:00",
+    )
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[{"id": 1, "url": "u"}])
+    tracking.mir_api.get_mission_queue_action = AsyncMock(
+        return_value={"id": 1, "action_id": "g1", "finished": "2026-08-10T10:04:00"}
+    )
+    await tracking.report_mission(STATUS, {})
+    report = published(tracking)[-1]
+    by_id = {t["taskId"]: t for t in report["tasks"]}
+    assert by_id["g1"]["completed"] is True
+    assert by_id["g2"]["completed"] is False  # untaken branch stays incomplete
+    assert report["completedPercent"] == 1  # finished missions keep the existing contract
+    assert report["status"] == "OK"
+    assert "endTs" in report

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -496,7 +496,63 @@ def published(tracking):
     return [c.kwargs["key_values"]["mission_tracking"] for c in calls]
 
 
-STATUS = {"robot_model": "MiR250", "uptime": 10, "serial_number": "s1"}
+STATUS = {"robot_model": "MiR250", "uptime": 10, "serial_number": "s1", "state_id": 3}
+
+
+@pytest.mark.asyncio
+async def test_report_mission_sends_status_while_executing():
+    """Without an explicit status the mission renders grey for its whole run.
+
+    The platform can only default a status from its own canonical state names, and MiR's
+    "Executing" is not one of them.
+    """
+    tracking = make_tracking()
+    wire_mission(tracking, [def_action("g1")])
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
+    await tracking.report_mission(STATUS, {})
+    report = published(tracking)[-1]
+    assert report["inProgress"] is True
+    assert report["status"] == "OK"
+
+
+@pytest.mark.asyncio
+async def test_report_mission_warns_while_robot_is_blocked():
+    # Paused (4), emergency stop (10) and error (12) all stop the mission progressing. The
+    # mission has not failed, so it is a warning rather than an error.
+    for state_id in (4, 10, 12):
+        tracking = make_tracking()
+        wire_mission(tracking, [def_action("g1")])
+        tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
+        await tracking.report_mission({**STATUS, "state_id": state_id}, {})
+        report = published(tracking)[-1]
+        assert report["status"] == "warning", state_id
+        assert report["inProgress"] is True
+
+
+@pytest.mark.asyncio
+async def test_report_mission_republishes_when_status_changes():
+    # Nothing else changes when the robot pauses, so without status in the dedup key the
+    # warning would never reach the platform.
+    tracking = make_tracking()
+    wire_mission(tracking, [def_action("g1")])
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
+    await tracking.report_mission(STATUS, {})
+    await tracking.report_mission(STATUS, {})
+    assert len(published(tracking)) == 1  # unchanged, deduplicated
+    await tracking.report_mission({**STATUS, "state_id": 4}, {})
+    assert [r["status"] for r in published(tracking)] == ["OK", "warning"]
+
+
+@pytest.mark.asyncio
+async def test_report_mission_done_is_ok_and_complete():
+    tracking = make_tracking()
+    wire_mission(tracking, [def_action("g1")], entry_state="Done", finished="2026-08-10T10:05:00")
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[])
+    await tracking.report_mission(STATUS, {})
+    report = published(tracking)[-1]
+    assert report["status"] == "OK"
+    assert report["completedPercent"] == 1
+    assert report["inProgress"] is False
 
 
 @pytest.mark.asyncio
@@ -593,4 +649,6 @@ async def test_report_mission_abort_completes_observed_only():
     assert by_id["g1"]["completed"] is True
     assert by_id["g2"]["completed"] is False  # untaken branch stays incomplete
     assert "endTs" in report
-    assert report["completedPercent"] == 1
+    # An aborted mission is not 100% done. Forcing 1 here contradicted the task list sent
+    # in the very same payload.
+    assert report["completedPercent"] == 0.5

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -3,9 +3,15 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
+import pytz
 from unittest.mock import AsyncMock, MagicMock
 
-from inorbit_mir_connector.src.mission_tracking import MirNativeMissionTasks
+from inorbit_edge.robot import RobotSession
+from inorbit_mir_connector.src.mir_api import MirApiV2
+from inorbit_mir_connector.src.mission_tracking import (
+    MirInorbitMissionTracking,
+    MirNativeMissionTasks,
+)
 
 
 def make_tasks(*guids):
@@ -126,3 +132,97 @@ async def test_empty_task_list_reports_zero_percent():
     await tracker.poll()
     fields = tracker.report_fields()
     assert fields["tasks"] == [] and fields["completedPercent"] == 0
+
+
+ACTION_DEFS = [
+    {"action_type": "move", "name": "Move"},
+    {"action_type": "docking", "name": "Docking"},
+    {"action_type": "charging", "name": "Charging"},
+]
+
+
+def make_tracking():
+    tracking = MirInorbitMissionTracking(
+        mir_api=MagicMock(autospec=MirApiV2),
+        inorbit_sess=MagicMock(autospec=RobotSession),
+        robot_tz_info=pytz.timezone("UTC"),
+        mission_executor=MagicMock(),
+    )
+    tracking.mission_executor.has_active_mission = AsyncMock(return_value=False)
+    tracking.mir_api.get_action_definitions = AsyncMock(return_value=ACTION_DEFS)
+    tracking.mir_api.get_position = AsyncMock(return_value={"name": "Warehouse-1"})
+    return tracking
+
+
+def def_action(guid, action_type="move", parameters=None):
+    return {
+        "guid": guid,
+        "action_type": action_type,
+        "parameters": parameters or [],
+        "priority": 1,
+        "mission_id": "def-guid",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_tasks_labels_and_order():
+    tracking = make_tracking()
+    actions = [
+        def_action("g1", "move", [{"id": "position", "value": "pos-guid"}]),
+        def_action("g2", "docking", [{"id": "marker", "value": "pos-guid"}]),
+        def_action("g3", "charging"),
+        def_action("g4", "unknown_type"),
+    ]
+    tasks = await tracking._build_tasks(actions)
+    assert list(tasks) == ["g1", "g2", "g3", "g4"]
+    assert tasks["g1"]["label"] == "Move to Warehouse-1"
+    assert tasks["g2"]["label"] == "Docking at Warehouse-1"
+    assert tasks["g3"]["label"] == "Charging"
+    assert tasks["g4"]["label"] == "unknown_type"
+    assert tasks["g1"] == {
+        "taskId": "g1",
+        "label": "Move to Warehouse-1",
+        "inProgress": False,
+        "completed": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_tasks_variable_position_falls_back_to_action_name():
+    # Parameterized missions carry input_name and a null value in the definition.
+    tracking = make_tracking()
+    actions = [def_action("g1", "move", [{"id": "position", "value": None, "input_name": "p"}])]
+    tasks = await tracking._build_tasks(actions)
+    assert tasks["g1"]["label"] == "Move"
+
+
+@pytest.mark.asyncio
+async def test_build_tasks_position_lookup_failure_falls_back():
+    tracking = make_tracking()
+    tracking.mir_api.get_position = AsyncMock(side_effect=RuntimeError("404"))
+    actions = [def_action("g1", "move", [{"id": "position", "value": "pos-guid"}])]
+    tasks = await tracking._build_tasks(actions)
+    assert tasks["g1"]["label"] == "Move"
+
+
+@pytest.mark.asyncio
+async def test_position_names_cached_across_actions():
+    tracking = make_tracking()
+    actions = [
+        def_action("g1", "move", [{"id": "position", "value": "pos-guid"}]),
+        def_action("g2", "move", [{"id": "position", "value": "pos-guid"}]),
+    ]
+    await tracking._build_tasks(actions)
+    assert tracking.mir_api.get_position.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_action_definitions_failure_uses_raw_types_and_retries():
+    tracking = make_tracking()
+    tracking.mir_api.get_action_definitions = AsyncMock(side_effect=RuntimeError("boom"))
+    tasks = await tracking._build_tasks([def_action("g1", "move")])
+    assert tasks["g1"]["label"] == "move"
+    # A later mission retries the fetch instead of caching the failure.
+    tracking.mir_api.get_action_definitions = AsyncMock(return_value=ACTION_DEFS)
+    tasks = await tracking._build_tasks([def_action("g2", "move")])
+    assert tasks["g2"]["label"] == "Move"

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -295,10 +295,49 @@ async def test_empty_task_list_reports_zero_percent():
     assert fields["tasks"] == [] and fields["completedPercent"] == 0
 
 
+POSITION_CHOICES = {
+    "choices": [
+        {"name": "Warehouse-1", "value": "pos-guid"},
+        {"name": "Dock charger 285", "value": "dock-guid"},
+    ]
+}
+
+# Shaped like GET /actions?whitelist=action_type,name,description,parameters on a real
+# robot: a label template plus, per parameter, the type and value list to fill it in.
 ACTION_DEFS = [
-    {"action_type": "move", "name": "Move"},
-    {"action_type": "docking", "name": "Docking"},
-    {"action_type": "charging", "name": "Charging"},
+    {
+        "action_type": "move",
+        "name": "Move",
+        "description": "Move to %(position)s",
+        "parameters": [{"id": "position", "type": "Reference", "constraints": POSITION_CHOICES}],
+    },
+    {
+        "action_type": "docking",
+        "name": "Docking",
+        "description": "Dock to %(marker)s",
+        "parameters": [{"id": "marker", "type": "Reference", "constraints": POSITION_CHOICES}],
+    },
+    {"action_type": "charging", "name": "Charging", "description": "Charging", "parameters": []},
+    {
+        "action_type": "wait",
+        "name": "Wait",
+        "description": "Wait for %(time)s.",
+        "parameters": [{"id": "time", "type": "Duration", "constraints": {}}],
+    },
+    {
+        "action_type": "wait_for_plc_register",
+        "name": "Wait for PLC register",
+        "description": "Wait for PLC register %(register)d to become %(value)f.",
+        "parameters": [
+            # Real PLC register choices have blank names.
+            {
+                "id": "register",
+                "type": "Reference",
+                "constraints": {"choices": [{"name": "", "value": 1}]},
+            },
+            {"id": "value", "type": "Float", "constraints": {}},
+        ],
+    },
 ]
 
 
@@ -311,7 +350,6 @@ def make_tracking():
     )
     tracking.mission_executor.has_active_mission = AsyncMock(return_value=False)
     tracking.mir_api.get_action_definitions = AsyncMock(return_value=ACTION_DEFS)
-    tracking.mir_api.get_position = AsyncMock(return_value={"name": "Warehouse-1"})
     return tracking
 
 
@@ -350,23 +388,43 @@ async def test_build_tasks_drops_scope_containers_but_keeps_their_body():
 async def test_build_tasks_labels_and_order():
     tracking = make_tracking()
     actions = [
-        def_action("g1", "move", [{"id": "position", "value": "pos-guid"}]),
-        def_action("g2", "docking", [{"id": "marker", "value": "pos-guid"}]),
-        def_action("g3", "charging"),
-        def_action("g4", "unknown_type"),
+        def_action("g1", "move", [{"id": "position", "value": "pos-guid"}], priority=1),
+        def_action("g2", "docking", [{"id": "marker", "value": "dock-guid"}], priority=2),
+        def_action("g3", "charging", priority=3),
+        def_action("g4", "unknown_type", priority=4),
+        def_action("g5", "wait", [{"id": "time", "value": "00:01:30.000000"}], priority=5),
     ]
     tasks = await tracking._build_tasks(actions)
-    assert list(tasks) == ["g1", "g2", "g3", "g4"]
+    assert list(tasks) == ["g1", "g2", "g3", "g4", "g5"]
     assert tasks["g1"]["label"] == "Move to Warehouse-1"
-    assert tasks["g2"]["label"] == "Docking at Warehouse-1"
+    assert tasks["g2"]["label"] == "Dock to Dock charger 285"
     assert tasks["g3"]["label"] == "Charging"
-    assert tasks["g4"]["label"] == "unknown_type"
+    # No definition at all (GET /actions does not list every type, e.g. load_mission):
+    # the raw action type, tidied up, is the last resort.
+    assert tasks["g4"]["label"] == "Unknown type"
+    assert tasks["g5"]["label"] == "Wait for 1 min 30 sec."
     assert tasks["g1"] == {
         "taskId": "g1",
         "label": "Move to Warehouse-1",
         "inProgress": False,
         "completed": False,
     }
+
+
+@pytest.mark.asyncio
+async def test_build_tasks_renders_non_reference_parameters():
+    # A reference whose choice has a blank name still resolves, to the raw value.
+    tracking = make_tracking()
+    actions = [
+        def_action(
+            "g1",
+            "wait_for_plc_register",
+            # MiR stores the register as a string where the choice value is an int.
+            [{"id": "register", "value": "1"}, {"id": "value", "value": 1.0}],
+        )
+    ]
+    tasks = await tracking._build_tasks(actions)
+    assert tasks["g1"]["label"] == "Wait for PLC register 1 to become 1.0."
 
 
 @pytest.mark.asyncio
@@ -379,23 +437,27 @@ async def test_build_tasks_variable_position_falls_back_to_action_name():
 
 
 @pytest.mark.asyncio
-async def test_build_tasks_position_lookup_failure_falls_back():
+async def test_build_tasks_unknown_position_falls_back_to_action_name():
+    # A position deleted from the robot is no longer among the action's choices. The label
+    # degrades to the action name rather than showing a bare guid.
     tracking = make_tracking()
-    tracking.mir_api.get_position = AsyncMock(side_effect=RuntimeError("404"))
-    actions = [def_action("g1", "move", [{"id": "position", "value": "pos-guid"}])]
+    actions = [def_action("g1", "move", [{"id": "position", "value": "deleted-guid"}])]
     tasks = await tracking._build_tasks(actions)
     assert tasks["g1"]["label"] == "Move"
 
 
 @pytest.mark.asyncio
-async def test_position_names_cached_across_actions():
+async def test_build_tasks_labels_need_no_extra_requests():
+    # Everything a label needs comes from the one cached /actions response.
     tracking = make_tracking()
     actions = [
         def_action("g1", "move", [{"id": "position", "value": "pos-guid"}]),
         def_action("g2", "move", [{"id": "position", "value": "pos-guid"}]),
     ]
     await tracking._build_tasks(actions)
-    assert tracking.mir_api.get_position.await_count == 1
+    await tracking._build_tasks(actions)
+    assert tracking.mir_api.get_action_definitions.await_count == 1
+    assert not [c for c in tracking.mir_api.mock_calls if "position" in str(c)]
 
 
 @pytest.mark.asyncio
@@ -403,7 +465,7 @@ async def test_action_definitions_failure_uses_raw_types_and_retries():
     tracking = make_tracking()
     tracking.mir_api.get_action_definitions = AsyncMock(side_effect=RuntimeError("boom"))
     tasks = await tracking._build_tasks([def_action("g1", "move")])
-    assert tasks["g1"]["label"] == "move"
+    assert tasks["g1"]["label"] == "Move"
     # A later mission retries the fetch instead of caching the failure.
     tracking.mir_api.get_action_definitions = AsyncMock(return_value=ACTION_DEFS)
     tasks = await tracking._build_tasks([def_action("g2", "move")])

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -11,7 +11,106 @@ from inorbit_mir_connector.src.mir_api import MirApiV2
 from inorbit_mir_connector.src.mission_tracking import (
     MirInorbitMissionTracking,
     MirNativeMissionTasks,
+    _execution_order,
 )
+
+# Real GET /missions/{id}/actions?whitelist=...,scope_reference payloads, trimmed to the
+# fields the ordering depends on.
+
+# "test mission tracking with movement": flat, but returned out of order. Ground truth from
+# GET /mission_queue/28525/actions is p12, p13 (the move), p14, p15, p16.
+FLAT_MISALIGNED = [
+    {"guid": "01cfdccd", "action_type": "wait", "priority": 12, "scope_reference": None},
+    {"guid": "aac8f71e", "action_type": "wait", "priority": 14, "scope_reference": None},
+    {"guid": "2d8240b7", "action_type": "wait", "priority": 15, "scope_reference": None},
+    {"guid": "60675cad", "action_type": "wait", "priority": 16, "scope_reference": None},
+    {"guid": "b7809d30", "action_type": "move", "priority": 13, "scope_reference": None},
+]
+
+# MiR's shipped "mirconst-guid-0000-0024-actionlist00": two scopes, each numbering its own
+# children from 0, so priority is meaningless as a global sort key.
+IF_SCOPE = "mirconst-guid-0002-0065-actlistparam"
+FIELDS_SCOPE = "mirconst-guid-0002-0073-actlistparam"
+SCOPED = [
+    {
+        "guid": "a-if",
+        "action_type": "if",
+        "priority": 0,
+        "scope_reference": None,
+        "parameters": [{"id": "true", "guid": IF_SCOPE, "value": ""}],
+    },
+    {
+        "guid": "a-throw",
+        "action_type": "throw_error",
+        "priority": 0,
+        "scope_reference": IF_SCOPE,
+        "parameters": [{"id": "message", "guid": "p-msg", "value": "no shelf"}],
+    },
+    {
+        "guid": "a-fields",
+        "action_type": "reduce_protective_fields",
+        "priority": 1,
+        "scope_reference": None,
+        "parameters": [{"id": "content", "guid": FIELDS_SCOPE, "value": ""}],
+    },
+    {
+        "guid": "a-load",
+        "action_type": "load_mission",
+        "priority": 0,
+        "scope_reference": FIELDS_SCOPE,
+        "parameters": [{"id": "mission_id", "guid": "p-mid", "value": "other"}],
+    },
+    {
+        "guid": "a-footprint",
+        "action_type": "set_footprint",
+        "priority": 1,
+        "scope_reference": FIELDS_SCOPE,
+        "parameters": [{"id": "footprint", "guid": "p-fp", "value": "fp"}],
+    },
+    {
+        "guid": "a-relmove",
+        "action_type": "relative_move",
+        "priority": 2,
+        "scope_reference": FIELDS_SCOPE,
+        "parameters": [{"id": "x", "guid": "p-x", "value": -2.0}],
+    },
+]
+
+
+def test_execution_order_flat_mission_uses_priority_not_list_order():
+    assert [a["guid"] for a in _execution_order(FLAT_MISALIGNED)] == [
+        "01cfdccd",
+        "b7809d30",
+        "aac8f71e",
+        "2d8240b7",
+        "60675cad",
+    ]
+
+
+def test_execution_order_keeps_nested_actions_inside_their_scope():
+    ordered = [a["guid"] for a in _execution_order(SCOPED)]
+    assert ordered == ["a-if", "a-throw", "a-fields", "a-load", "a-footprint", "a-relmove"]
+    # A global sort by priority hoists the nested load_mission out of its scope, above the
+    # top-level action that contains it. That is the trap this function exists to avoid.
+    naive = [a["guid"] for a in sorted(SCOPED, key=lambda a: a["priority"])]
+    assert naive.index("a-load") < naive.index("a-fields")
+    assert ordered.index("a-load") > ordered.index("a-fields")
+
+
+def test_execution_order_survives_malformed_input():
+    # Parameters without guids must not be read as nesting at the root, and a scope cycle
+    # must not hang the poll loop.
+    cyclic = [
+        {
+            "guid": "x",
+            "action_type": "loop",
+            "priority": 0,
+            "scope_reference": "s",
+            "parameters": [{"id": "content", "guid": "s"}, {"id": "noguid"}],
+        }
+    ]
+    assert [a["guid"] for a in _execution_order(cyclic)] == ["x"]
+    assert _execution_order([]) == []
 
 
 def make_tasks(*guids):
@@ -216,14 +315,35 @@ def make_tracking():
     return tracking
 
 
-def def_action(guid, action_type="move", parameters=None):
+def def_action(guid, action_type="move", parameters=None, priority=1, scope_reference=None):
     return {
         "guid": guid,
         "action_type": action_type,
         "parameters": parameters or [],
-        "priority": 1,
+        "priority": priority,
+        "scope_reference": scope_reference,
         "mission_id": "def-guid",
     }
+
+
+@pytest.mark.asyncio
+async def test_build_tasks_drops_scope_containers_but_keeps_their_body():
+    tracking = make_tracking()
+    body_scope = "p-content"
+    actions = [
+        def_action(
+            "g-loop",
+            "loop",
+            [{"id": "content", "guid": body_scope, "value": ""}],
+            priority=0,
+        ),
+        def_action("g-inner", "move", priority=0, scope_reference=body_scope),
+        def_action("g-after", "docking", priority=1),
+    ]
+    tasks = await tracking._build_tasks(actions)
+    # The loop itself is a container: it may never report finished, and while its body runs
+    # it would show as a second task in progress.
+    assert list(tasks) == ["g-inner", "g-after"]
 
 
 @pytest.mark.asyncio

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -126,6 +126,28 @@ async def test_signature_changes_only_on_state_change():
 
 
 @pytest.mark.asyncio
+async def test_detail_fetches_capped_per_poll_and_converge_over_ticks():
+    # Long queue-action history (e.g. attaching mid-patrol): entry 1 is already finished,
+    # entries 2-30 are still unfinished.
+    guids = [f"g{i}" for i in range(1, 31)]
+    details = {1: ("g1", "2026-08-10T10:00:00")}
+    details.update({i: (f"g{i}", None) for i in range(2, 31)})
+    api = make_api(
+        queue_actions=[{"id": i, "url": "u"} for i in range(1, 31)],
+        details=details,
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks(*guids))
+
+    await tracker.poll()
+    assert api.get_mission_queue_action.await_count == 25
+    by_id = {t["taskId"]: t for t in tracker.report_fields()["tasks"]}
+    assert by_id["g1"]["completed"] is True  # fetched-and-finished entry still applies
+
+    await tracker.poll()
+    assert api.get_mission_queue_action.await_count > 25  # cache-missing ones refetched
+
+
+@pytest.mark.asyncio
 async def test_empty_task_list_reports_zero_percent():
     api = make_api(queue_actions=[])
     tracker = MirNativeMissionTasks(api, 99, {})
@@ -325,3 +347,28 @@ async def test_report_mission_done_completes_observed_only():
     assert report["completedPercent"] == 1  # finished missions keep the existing contract
     assert report["status"] == "OK"
     assert "endTs" in report
+
+
+@pytest.mark.asyncio
+async def test_report_mission_abort_completes_observed_only():
+    # Mission aborted with an untaken if-branch action (g2 never appears in queue actions).
+    tracking = make_tracking()
+    wire_mission(
+        tracking,
+        [def_action("g1"), def_action("g2")],
+        entry_state="Abort",
+        finished="2026-08-10T10:05:00",
+    )
+    tracking.mir_api.get_mission_queue_actions = AsyncMock(return_value=[{"id": 1, "url": "u"}])
+    tracking.mir_api.get_mission_queue_action = AsyncMock(
+        return_value={"id": 1, "action_id": "g1", "finished": "2026-08-10T10:04:00"}
+    )
+    await tracking.report_mission(STATUS, {})
+    report = published(tracking)[-1]
+    by_id = {t["taskId"]: t for t in report["tasks"]}
+    assert report["state"] == "Aborted"  # merged from 'Abort'
+    assert report["status"] == "error"
+    assert by_id["g1"]["completed"] is True
+    assert by_id["g2"]["completed"] is False  # untaken branch stays incomplete
+    assert "endTs" in report
+    assert report["completedPercent"] == 1

--- a/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
+++ b/mir_connector/inorbit_mir_connector/tests/test_mission_tracking_tasks.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from inorbit_mir_connector.src.mission_tracking import MirNativeMissionTasks
+
+
+def make_tasks(*guids):
+    return {
+        g: {"taskId": g, "label": f"Task {g}", "inProgress": False, "completed": False}
+        for g in guids
+    }
+
+
+def make_api(queue_actions=None, details=None):
+    """details: {int_id: (action_id, finished_or_None)}"""
+    api = MagicMock()
+    api.get_mission_queue_actions = AsyncMock(return_value=queue_actions or [])
+
+    async def get_detail(queue_id, int_id):
+        action_id, finished = details[int_id]
+        return {"id": int_id, "action_id": action_id, "finished": finished, "state": ""}
+
+    api.get_mission_queue_action = AsyncMock(side_effect=get_detail)
+    return api
+
+
+@pytest.mark.asyncio
+async def test_progresses_tasks_from_queue_actions():
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}, {"id": 2, "url": "u"}],
+        details={1: ("g1", "2026-08-10T10:00:00"), 2: ("g2", None)},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1", "g2", "g3"))
+    await tracker.poll()
+    fields = tracker.report_fields()
+    by_id = {t["taskId"]: t for t in fields["tasks"]}
+    assert by_id["g1"] == {
+        "taskId": "g1",
+        "label": "Task g1",
+        "inProgress": False,
+        "completed": True,
+    }
+    assert by_id["g2"]["inProgress"] is True and by_id["g2"]["completed"] is False
+    assert by_id["g3"]["inProgress"] is False and by_id["g3"]["completed"] is False
+    assert fields["currentTaskId"] == "g2"
+    assert fields["completedPercent"] == pytest.approx(1 / 3)
+
+
+@pytest.mark.asyncio
+async def test_finished_details_are_not_refetched():
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}],
+        details={1: ("g1", "2026-08-10T10:00:00")},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1"))
+    await tracker.poll()
+    await tracker.poll()
+    assert api.get_mission_queue_action.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_reexecution_never_downgrades_completed():
+    # A loop re-runs the same definition action: new int id, same action_id (guid).
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}, {"id": 2, "url": "u"}],
+        details={1: ("g1", "2026-08-10T10:00:00"), 2: ("g1", None)},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1", "g2"))
+    await tracker.poll()
+    task = {t["taskId"]: t for t in tracker.report_fields()["tasks"]}["g1"]
+    assert task["completed"] is True and task["inProgress"] is False
+    assert "currentTaskId" not in tracker.report_fields()
+
+
+@pytest.mark.asyncio
+async def test_foreign_guids_ignored():
+    # load_mission inlines sub-mission actions whose guids are not in the definition.
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}],
+        details={1: ("foreign-guid", None)},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1"))
+    await tracker.poll()
+    fields = tracker.report_fields()
+    assert fields["tasks"][0]["inProgress"] is False
+    assert "currentTaskId" not in fields
+    assert fields["completedPercent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_poll_failure_keeps_previous_states_and_does_not_raise():
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}],
+        details={1: ("g1", "2026-08-10T10:00:00")},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1"))
+    await tracker.poll()
+    api.get_mission_queue_actions = AsyncMock(side_effect=RuntimeError("boom"))
+    await tracker.poll()  # must not raise
+    assert tracker.report_fields()["tasks"][0]["completed"] is True
+
+
+@pytest.mark.asyncio
+async def test_signature_changes_only_on_state_change():
+    api = make_api(
+        queue_actions=[{"id": 1, "url": "u"}],
+        details={1: ("g1", None)},
+    )
+    tracker = MirNativeMissionTasks(api, 99, make_tasks("g1", "g2"))
+    sig0 = tracker.signature()
+    await tracker.poll()
+    sig1 = tracker.signature()
+    assert sig0 != sig1
+    await tracker.poll()
+    assert tracker.signature() == sig1
+
+
+@pytest.mark.asyncio
+async def test_empty_task_list_reports_zero_percent():
+    api = make_api(queue_actions=[])
+    tracker = MirNativeMissionTasks(api, 99, {})
+    await tracker.poll()
+    fields = tracker.report_fields()
+    assert fields["tasks"] == [] and fields["completedPercent"] == 0


### PR DESCRIPTION
Reports native (robot-triggered) MiR missions to InOrbit Mission Tracking with one task per mission step, in execution order, labeled the way MiR labels them. The native path previously published mission-level state and a count-based percent only.

## How it works

`MirNativeMissionTasks` follows each executing queue entry: a shallow `GET /mission_queue/{id}/actions` plus per-action detail GETs with a finished-cache, matching each queue `action_id` back to a definition action guid. Detail fetches are capped per poll so attaching mid-mission cannot stall the telemetry loop. The mission definition is cached per queue entry, and the executing queue id is read from `/status`, which the connector already fetches every tick.

**Task order.** `GET /missions/{id}/actions` returns actions in no meaningful order, and `priority` is not a global rank: it orders siblings within one scope, and each scope numbers its children from zero. The list is a tree linked by `scope_reference`, which holds the guid of a parameter of the containing action. That field is not in the default response, so it is whitelisted, and the tree is walked depth-first.

**Task labels.** `GET /actions` is whitelisted for `name,description,parameters`, which returns a label template per action type (`Move to %(position)s`) and the parameter metadata to fill it in. Rendering is generic rather than per-action-type: `Reference` and `Selection` parameters resolve against their own value lists, `Duration` is formatted, everything else is stringified. Labels are localized by the `Accept-Language` header the connector already sends.

```
Wait for 10 sec.
Move to Dock charger 285
Wait for PLC register 1 to become 1.0.
```

**Completion.** A step completes only when its action finished without failing; MiR sets `finished` on failures too and marks success with an empty `state`. Completed tasks never downgrade, and foreign guids from `load_mission` inlining are ignored. Scope-bearing actions (`loop`, `if`, `try_catch`, ...) are containers rather than steps and are left out of the task list, reusing the existing `_SCOPE_BEARING_DENIED` set; the steps inside them are kept.

The executor path (InOrbit-dispatched missions) is unchanged and still owns tracking while it has an active mission.

## Mission states

Every report carries a status, and the status is a function of the state. MiR keeps a queue entry in `Executing` whether the robot is driving, paused or emergency-stopped, so the robot state supplies the rest.

| Mission state | Status | When |
| --- | --- | --- |
| `Executing` | `OK` | Running normally |
| `Paused` | `warning` | Robot paused; the mission is still open |
| `Emergency stop` | `warning` | Emergency stop pressed mid-mission |
| `Error` | `error` | Robot in an error state mid-mission |
| `Done` | `OK` | Finished |
| `Aborted` | `error` | Cancelled or failed |

`inProgress` follows MiR's queue state rather than the reported one: reporting it false while blocked would make the platform stamp an end time and close the mission.

Only `state_id` 4 is corroborated, by `MirApiV2.SetStateId.PAUSE`. 10 and 12 come from the MiR web interface and are unconfirmed; an unrecognised id leaves the mission `Executing`.

## Also fixed

Defects found while testing this against a robot, each in its own commit.

- No status was sent while a mission ran. The platform infers one from its own canonical state names, and MiR's `Executing` is not one of them, so missions rendered with no status for their entire run.
- Fleet-dispatched ActionLists carry `mission_id: null`. `GET /missions/None` is a 400 and `executing_mission_id` was never cleared, so `report_mission` raised on every tick and mission tracking stayed dead for the rest of the process. These entries dominate the queue on a fleet-managed robot.
- Finding the executing mission fetched the entire `mission_queue` every tick. The robot never truncates it, so on a long-lived robot that is tens of thousands of entries and megabytes per call, at 1 Hz. It now comes from `/status`, with a bounded newest-N query as fallback.
- Failed steps reported as completed, and stayed `inProgress` for the life of the mission record. The same signal is fixed on the dispatched path in `behavior_tree`.
- An aborted mission reported `completedPercent` 1 while the task list in the same payload showed the run stopping partway.
- The non-tracker `completedPercent` fallback read a field that became a URL string when `get_mission` was replaced by `get_mission_queue_entry`, clamping to a permanent 100%. The branch was unreachable and is deleted.

`get_position` and the position name cache are removed: `move.position` already carries guid-to-name in its own parameter metadata, so labels cost no extra requests, and a position deleted from the robot degrades to `Move` instead of a 404.

## Limitations

Documented in the README rather than worked around: loops report one task per step rather than per iteration, untaken `if` and `try_catch` branches never complete, `load_mission` sub-missions are not expanded, and fleet ActionLists have no task list.

Loop handling is not hardened. Whether a `loop` re-emits the same definition guid per iteration is unconfirmed, so that work is deferred rather than written against an assumption.

## Testing

233 unit tests, black and flake8 clean at line length 100. Tests that asserted the above defects as intended behavior were rewritten, and fixtures that invented API fields now match real response shapes.

Verified against a robot: a full mission reports `status: OK` on every in-flight update with ordered readable labels and monotonic progress, the ordering walk reproduces the `action_id` sequence of a recorded queue run, and a whole mission runs with no unbounded queue reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
