### PR TITLE
feat(gausium): mirror vendor offline into InOrbit robot status

### DIFF
--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
@@ -237,6 +237,8 @@ class PhantasConnector(Connector):
         # connector doesn't show an unreachable robot as online with stale
         # data. ponytail: no debounce — a one-poll flap only re-sends a
         # retained message.
+        # TODO: move vendor-offline passthrough into inorbit-connector and
+        # refactor this and the Pudu connector to use it.
         online = status.get("online")
         if isinstance(online, bool) and online != self._vendor_online:
             if self._vendor_online is None:

--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
@@ -81,6 +81,10 @@ class PhantasConnector(Connector):
             ),
         )
 
+        # Last vendor-reported reachability (status "online" field), mirrored
+        # into the InOrbit online status. See _execution_loop.
+        self._vendor_online: bool | None = None
+
     async def _connect(self) -> None:
         """Connect to the robot services.
 
@@ -227,6 +231,25 @@ class PhantasConnector(Connector):
         if not status:
             self._logger.debug("No robot status available yet")
             return
+
+        # Vendor-offline passthrough: mirror the vendor cloud's reachability
+        # (status "online" field) into the InOrbit online status — the same
+        # retained state message the MQTT last-will uses — so a running
+        # connector doesn't show an unreachable robot as online with stale
+        # data. ponytail: no debounce — a one-poll flap only re-sends a
+        # retained message.
+        online = status.get("online")
+        if isinstance(online, bool) and online != self._vendor_online:
+            if self._vendor_online is None:
+                # Keep InOrbit's get_state probes consistent with the last
+                # vendor report.
+                self._robot_session.set_online_status_callback(
+                    lambda: self._vendor_online is not False
+                )
+            if self._vendor_online is not None or not online:
+                # Skip the initial online report: connect() already published it.
+                self._robot_session._send_robot_status(online=online)
+            self._vendor_online = online
 
         # Publish pose
         # mapPosition returns:

--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
@@ -26,7 +26,6 @@ from .robot import RemoteTaskCommandType
 from .robot import RobotAPI
 from .robot.robot import Robot
 
-
 # Pose is received in pixels. It must be coverted to meters before publishing to inorbit
 MAP_RESOLUTION = 0.05  # meters per pixel
 

--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
@@ -231,14 +231,12 @@ class PhantasConnector(Connector):
             self._logger.debug("No robot status available yet")
             return
 
-        # Vendor-offline passthrough: mirror the vendor cloud's reachability
-        # (status "online" field) into the InOrbit online status — the same
-        # retained state message the MQTT last-will uses — so a running
-        # connector doesn't show an unreachable robot as online with stale
-        # data. ponytail: no debounce — a one-poll flap only re-sends a
-        # retained message.
-        # TODO: move vendor-offline passthrough into inorbit-connector and
-        # refactor this and the Pudu connector to use it.
+        # Mirror the vendor cloud's reachability (status "online" field) into
+        # the InOrbit online status — the same retained state message the
+        # MQTT last-will uses. No debounce: a flap only re-sends a retained
+        # message.
+        # TODO: move this into inorbit-connector and refactor this and the
+        # Pudu connector to use it.
         online = status.get("online")
         if isinstance(online, bool) and online != self._vendor_online:
             if self._vendor_online is None:

--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/mission.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/mission.py
@@ -16,7 +16,6 @@ from ..config.connector_model import DEFAULT_MISSION_SUCCESS_PERCENTAGE_THRESHOL
 from .robot import RobotAPI
 from .robot import TaskState
 
-
 # The progress bar is advanced to 100% if the progress percentage is greater than this threshold
 MISSION_PROGRESS_BAR_ADVANCED_PERCENTAGE_THRESHOLD = 0.90
 

--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/robot/base_api_client.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/robot/base_api_client.py
@@ -22,7 +22,6 @@ from tenacity import retry_if_exception_type
 from tenacity import stop_after_attempt
 from tenacity import wait_fixed
 
-
 # OAuth2 token request URL for Gausium API
 REQUEST_TOKEN_URL = "https://openapi.gs-robot.com/gas/api/v1alpha1/oauth/token"
 

--- a/gausium_open_platform_connector/inorbit_gausium_connector/tests/test_connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/tests/test_connector.py
@@ -283,3 +283,23 @@ async def test_connector_with_none_user_scripts_dir(monkeypatch):
     )
     assert connector is not None
     assert connector.robot_api is not None
+
+
+@pytest.mark.asyncio
+async def test_execution_loop_mirrors_vendor_offline_into_robot_status(
+    connector: PhantasConnector,
+):
+    """Vendor online=False flips the InOrbit online status; the initial online is not re-sent."""
+    connector.robot.status_v2 = {}
+
+    await connector._execution_loop()
+    connector._robot_session._send_robot_status.assert_not_called()
+    assert connector._robot_session.set_online_status_callback.called
+
+    connector.robot.status = {"online": False}
+    await connector._execution_loop()
+    connector._robot_session._send_robot_status.assert_called_with(online=False)
+
+    connector.robot.status = {"online": True}
+    await connector._execution_loop()
+    connector._robot_session._send_robot_status.assert_called_with(online=True)


### PR DESCRIPTION
A running connector kept vendor-unreachable robots (status `online: false`) shown as online in InOrbit with stale data for hours.

Mirrors the vendor cloud's reachability into the InOrbit online status: `set_online_status_callback` answers `get_state` probes, and transitions publish the same retained state message the MQTT last-will uses. No connection drops, no debounce (a one-poll flap just re-sends a retained message).