### PR TITLE
fix(gausium): stop publishing while vendor-offline

### DIFF
--- a/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/src/connector.py
@@ -249,6 +249,12 @@ class PhantasConnector(Connector):
                 # Skip the initial online report: connect() already published it.
                 self._robot_session._send_robot_status(online=online)
             self._vendor_online = online
+        if self._vendor_online is False:
+            # Publishing while offline would keep refreshing the robot's
+            # updateStamp, so it never ages out of "recently online" views
+            # (e.g. the fleet status widget). Data is stale anyway; polling
+            # continues and publishing resumes on reconnect.
+            return
 
         # Publish pose
         # mapPosition returns:

--- a/gausium_open_platform_connector/inorbit_gausium_connector/tests/test_connector.py
+++ b/gausium_open_platform_connector/inorbit_gausium_connector/tests/test_connector.py
@@ -295,11 +295,15 @@ async def test_execution_loop_mirrors_vendor_offline_into_robot_status(
     await connector._execution_loop()
     connector._robot_session._send_robot_status.assert_not_called()
     assert connector._robot_session.set_online_status_callback.called
+    assert connector._robot_session.publish_key_values.call_count == 1
 
     connector.robot.status = {"online": False}
     await connector._execution_loop()
     connector._robot_session._send_robot_status.assert_called_with(online=False)
+    # No publishing while offline: it would keep refreshing updateStamp.
+    assert connector._robot_session.publish_key_values.call_count == 1
 
     connector.robot.status = {"online": True}
     await connector._execution_loop()
     connector._robot_session._send_robot_status.assert_called_with(online=True)
+    assert connector._robot_session.publish_key_values.call_count == 2


### PR DESCRIPTION
Follow-up to #127 (stacked on it): publishing telemetry for a vendor-offline robot keeps refreshing its `updateStamp`, so it never ages out of recently-online views (the fleet status widget shows it forever). Skip all publishing while offline — polling continues and publishing resumes on reconnect.